### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate display initials

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2024-05-24 - Flutter IndexedStack Initialization
 **Learning:** In Flutter applications, using a standard `IndexedStack` to manage bottom navigation views eagerly initializes and builds *all* of its children simultaneously upon creation. This causes all hidden views to unnecessarily execute their `initState` lifecycle methods (which often involve expensive operations like API calls to Firestore) during app launch, degrading startup performance and consuming redundant bandwidth.
 **Action:** Avoid eager initialization of all tabs within an `IndexedStack`. Implement a lazy initialization strategy by tracking visited tabs (e.g., using a `Set<int> _initializedTabs`) and conditionally rendering unvisited tabs as `SizedBox.shrink()` to defer their instantiation until the user actually navigates to them.
+
+## 2026-03-27 - Pre-calculated Initials
+**Learning:** In Flutter, complex string manipulations (like `displayName.split(' ').where(...).take(2).map(...).join().toUpperCase()`) placed directly inside a `build` method (e.g., in `HomeView` or `ProfileView`) cause unnecessary overhead and redundant string allocations on every UI rebuild.
+**Action:** Move expensive state-derived computations out of the `build` method and into the view model (e.g., `AuthViewModel`). Pre-calculate the result (like `initials`) when the underlying state changes, so the UI only reads a cached value.

--- a/lib/viewmodels/auth_viewmodel.dart
+++ b/lib/viewmodels/auth_viewmodel.dart
@@ -19,17 +19,36 @@ class AuthViewModel extends ChangeNotifier {
   String get email => currentUser?.email ?? '';
   String? get photoUrl => currentUser?.photoURL;
 
+  // Optimization: Pre-calculate initials when user state changes to avoid expensive
+  // string manipulation (split, where, take, map, join) on every UI rebuild
+  String _initials = 'U';
+  String get initials => _initials;
+
   AuthViewModel() {
     _auth.authStateChanges().listen((User? user) {
       if (user == null) {
         _isAuthenticated = false;
         _token = null;
+        _initials = 'U';
       } else {
         _isAuthenticated = true;
         _token = user.uid;
+        _updateInitials(user.displayName);
       }
       notifyListeners();
     });
+  }
+
+  void _updateInitials(String? name) {
+    final displayName = name ?? 'Learner';
+    final computedInitials = displayName
+        .split(' ')
+        .where((s) => s.isNotEmpty)
+        .take(2)
+        .map((s) => s[0])
+        .join()
+        .toUpperCase();
+    _initials = computedInitials.isEmpty ? 'U' : computedInitials;
   }
 
   String _parseFirebaseError(dynamic e) {
@@ -61,10 +80,7 @@ class AuthViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      await _auth.signInWithEmailAndPassword(
-        email: email,
-        password: password,
-      );
+      await _auth.signInWithEmailAndPassword(email: email, password: password);
     } catch (e) {
       _isLoading = false;
       notifyListeners();
@@ -103,8 +119,8 @@ class AuthViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final GoogleSignInAccount? googleUser =
-          await GoogleSignIn.instance.authenticate();
+      final GoogleSignInAccount? googleUser = await GoogleSignIn.instance
+          .authenticate();
       if (googleUser == null) {
         _isLoading = false;
         notifyListeners();

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -167,16 +167,9 @@ class _HomeViewState extends State<HomeView> {
   }
 
   Widget _buildInitials(AuthViewModel auth) {
-    final initials = auth.displayName
-        .split(' ')
-        .where((s) => s.isNotEmpty)
-        .take(2)
-        .map((s) => s[0])
-        .join()
-        .toUpperCase();
     return Center(
       child: Text(
-        initials.isEmpty ? 'U' : initials,
+        auth.initials,
         style: const TextStyle(
           color: Colors.white,
           fontWeight: FontWeight.bold,
@@ -223,18 +216,20 @@ class _HomeViewState extends State<HomeView> {
           const [Color(0xFF06B6D4), Color(0xFF3B82F6)],
         ),
         const SizedBox(width: 12),
-        _buildStatCard(
-          'Progress',
-          '0%',
-          Icons.trending_up_rounded,
-          const [Color(0xFF10B981), Color(0xFF059669)],
-        ),
+        _buildStatCard('Progress', '0%', Icons.trending_up_rounded, const [
+          Color(0xFF10B981),
+          Color(0xFF059669),
+        ]),
       ],
     );
   }
 
   Widget _buildStatCard(
-      String label, String value, IconData icon, List<Color> colors) {
+    String label,
+    String value,
+    IconData icon,
+    List<Color> colors,
+  ) {
     return Expanded(
       child: GlassCard(
         borderRadius: 16,
@@ -253,10 +248,7 @@ class _HomeViewState extends State<HomeView> {
             const SizedBox(height: 12),
             Text(
               value,
-              style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
-              ),
+              style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
             ),
             Text(
               label,
@@ -277,10 +269,7 @@ class _HomeViewState extends State<HomeView> {
       children: [
         Text(
           title,
-          style: const TextStyle(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-          ),
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
         ),
         if (_videos.isNotEmpty || _courses.isNotEmpty)
           TextButton(
@@ -329,8 +318,9 @@ class _HomeViewState extends State<HomeView> {
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
                   ),
-                  borderRadius:
-                      const BorderRadius.vertical(top: Radius.circular(20)),
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(20),
+                  ),
                 ),
                 child: Stack(
                   children: [
@@ -346,7 +336,8 @@ class _HomeViewState extends State<HomeView> {
                     if (course.thumbnailUrl.isNotEmpty)
                       ClipRRect(
                         borderRadius: const BorderRadius.vertical(
-                            top: Radius.circular(20)),
+                          top: Radius.circular(20),
+                        ),
                         child: CachedNetworkImage(
                           imageUrl: course.thumbnailUrl,
                           fit: BoxFit.cover,
@@ -360,7 +351,9 @@ class _HomeViewState extends State<HomeView> {
                       left: 8,
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 4),
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
                         decoration: BoxDecoration(
                           color: Colors.black.withValues(alpha: 0.5),
                           borderRadius: BorderRadius.circular(8),
@@ -372,13 +365,18 @@ class _HomeViewState extends State<HomeView> {
                           child: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const Icon(Icons.star_rounded,
-                                  color: Colors.amber, size: 14),
+                              const Icon(
+                                Icons.star_rounded,
+                                color: Colors.amber,
+                                size: 14,
+                              ),
                               const SizedBox(width: 4),
                               Text(
                                 course.rating.toStringAsFixed(1),
                                 style: const TextStyle(
-                                    color: Colors.white, fontSize: 12),
+                                  color: Colors.white,
+                                  fontSize: 12,
+                                ),
                               ),
                             ],
                           ),
@@ -533,10 +531,7 @@ class _HomeViewState extends State<HomeView> {
           const SizedBox(height: 20),
           const Text(
             'Welcome to Hackston!',
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-            ),
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
           const Text(

--- a/lib/views/profile/profile_view.dart
+++ b/lib/views/profile/profile_view.dart
@@ -103,17 +103,15 @@ class ProfileView extends StatelessWidget {
                   style: OutlinedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     side: BorderSide(
-                        color: AppTheme.error.withValues(alpha: 0.3)),
+                      color: AppTheme.error.withValues(alpha: 0.3),
+                    ),
                   ),
                 ),
               ),
               const SizedBox(height: 20),
               const Text(
                 'Hackston LMS v1.0.0',
-                style: TextStyle(
-                  color: AppTheme.textMuted,
-                  fontSize: 12,
-                ),
+                style: TextStyle(color: AppTheme.textMuted, fontSize: 12),
               ),
             ],
           ),
@@ -123,14 +121,6 @@ class ProfileView extends StatelessWidget {
   }
 
   Widget _buildAvatar(AuthViewModel auth) {
-    final initials = auth.displayName
-        .split(' ')
-        .where((s) => s.isNotEmpty)
-        .take(2)
-        .map((s) => s[0])
-        .join()
-        .toUpperCase();
-
     return Container(
       width: 88,
       height: 88,
@@ -154,7 +144,7 @@ class ProfileView extends StatelessWidget {
                 height: 88,
                 errorWidget: (_, __, ___) => Center(
                   child: Text(
-                    initials.isEmpty ? 'U' : initials,
+                    auth.initials,
                     style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,
@@ -166,7 +156,7 @@ class ProfileView extends StatelessWidget {
             )
           : Center(
               child: Text(
-                initials.isEmpty ? 'U' : initials,
+                auth.initials,
                 style: const TextStyle(
                   color: Colors.white,
                   fontWeight: FontWeight.bold,
@@ -206,18 +196,12 @@ class ProfileView extends StatelessWidget {
       children: [
         Text(
           value,
-          style: const TextStyle(
-            fontSize: 22,
-            fontWeight: FontWeight.bold,
-          ),
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 4),
         Text(
           label,
-          style: const TextStyle(
-            color: AppTheme.textSecondary,
-            fontSize: 13,
-          ),
+          style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
         ),
       ],
     );
@@ -252,20 +236,27 @@ class ProfileView extends StatelessWidget {
                       borderRadius: index == 0 && items.length == 1
                           ? BorderRadius.circular(16)
                           : index == 0
-                              ? const BorderRadius.vertical(
-                                  top: Radius.circular(16))
-                              : index == items.length - 1
-                                  ? const BorderRadius.vertical(
-                                      bottom: Radius.circular(16))
-                                  : BorderRadius.zero,
+                          ? const BorderRadius.vertical(
+                              top: Radius.circular(16),
+                            )
+                          : index == items.length - 1
+                          ? const BorderRadius.vertical(
+                              bottom: Radius.circular(16),
+                            )
+                          : BorderRadius.zero,
                       onTap: item.onTap,
                       child: Padding(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 18, vertical: 16),
+                          horizontal: 18,
+                          vertical: 16,
+                        ),
                         child: Row(
                           children: [
-                            Icon(item.icon,
-                                color: AppTheme.textSecondary, size: 22),
+                            Icon(
+                              item.icon,
+                              color: AppTheme.textSecondary,
+                              size: 22,
+                            ),
                             const SizedBox(width: 14),
                             Expanded(
                               child: Text(
@@ -275,8 +266,11 @@ class ProfileView extends StatelessWidget {
                             ),
                             if (item.trailing != null) item.trailing!,
                             if (item.trailing == null)
-                              const Icon(Icons.chevron_right_rounded,
-                                  color: AppTheme.textMuted, size: 22),
+                              const Icon(
+                                Icons.chevron_right_rounded,
+                                color: AppTheme.textMuted,
+                                size: 22,
+                              ),
                           ],
                         ),
                       ),
@@ -318,8 +312,10 @@ class ProfileView extends StatelessWidget {
               Navigator.pop(ctx);
               auth.logout();
             },
-            child:
-                const Text('Sign Out', style: TextStyle(color: AppTheme.error)),
+            child: const Text(
+              'Sign Out',
+              style: TextStyle(color: AppTheme.error),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
💡 What:
Moved the logic for generating user initials (which involves splitting, filtering, mapping, and joining strings) from the `build` methods of `HomeView` and `ProfileView` into `AuthViewModel`. The `initials` are now computed exactly once whenever the user's authentication state or display name updates, and the views simply read this cached property.

🎯 Why:
In Flutter, operations within the `build` method are executed frequently. Complex string manipulations and intermediate list allocations within the build cycle cause unnecessary garbage collection overhead and minor CPU usage. Moving state-derived computations to the ViewModel ensures the UI layer remains lean and performant.

📊 Impact:
Eliminates redundant string splitting, filtering, and mapping operations across two primary views during widget rebuilds (e.g., when toggling themes, typing in search, or updating other transient state).

🔬 Measurement:
Run `flutter analyze` and `flutter test` to ensure no regressions in authentication logic or UI rendering. Profile the memory allocations before and after navigating between `HomeView` and `ProfileView` to verify reduced string garbage generation.

---
*PR created automatically by Jules for task [9511169667639032273](https://jules.google.com/task/9511169667639032273) started by @manupawickramasinghe*