### PR TITLE
🧪 [testing improvement] Add coverage for AuthViewModel._parseFirebaseError

### DIFF
--- a/lib/viewmodels/auth_viewmodel.dart
+++ b/lib/viewmodels/auth_viewmodel.dart
@@ -3,7 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 class AuthViewModel extends ChangeNotifier {
-  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseAuth _auth;
 
   bool _isAuthenticated = false;
   bool get isAuthenticated => _isAuthenticated;
@@ -41,7 +41,7 @@ class AuthViewModel extends ChangeNotifier {
     return _cachedInitials!;
   }
 
-  AuthViewModel() {
+  AuthViewModel({FirebaseAuth? auth}) : _auth = auth ?? FirebaseAuth.instance {
     _auth.authStateChanges().listen((User? user) {
       // Clear cached initials when auth state changes
       _cachedInitials = null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -721,10 +721,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/test/viewmodels/auth_viewmodel_test.dart
+++ b/test/viewmodels/auth_viewmodel_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hackston_lms/viewmodels/auth_viewmodel.dart';
+import 'dart:async';
+
+// Manually mock FirebaseAuthException
+class FakeFirebaseAuthException implements FirebaseAuthException {
+  @override
+  final String code;
+  @override
+  final String? message;
+
+  @override
+  final String plugin = 'firebase_auth';
+
+  @override
+  final StackTrace? stackTrace = null;
+
+  @override
+  final String? email;
+  @override
+  final AuthCredential? credential;
+  @override
+  final String? tenantId;
+  @override
+  final String? phoneNumber;
+
+  FakeFirebaseAuthException({
+    required this.code,
+    this.message,
+    this.email,
+    this.credential,
+    this.tenantId,
+    this.phoneNumber,
+  });
+}
+
+// Mock FirebaseAuth that throws exceptions when signInWithEmailAndPassword is called
+class MockFirebaseAuth extends Fake implements FirebaseAuth {
+  Object? errorToThrow;
+
+  // Create a StreamController to provide a fake auth state stream
+  final _authStateController = StreamController<User?>.broadcast();
+
+  @override
+  Stream<User?> authStateChanges() => _authStateController.stream;
+
+  @override
+  Future<UserCredential> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {
+    if (errorToThrow != null) {
+      throw errorToThrow!;
+    }
+    throw UnimplementedError('Not implemented for success case in this test.');
+  }
+
+  void dispose() {
+    _authStateController.close();
+  }
+}
+
+void main() {
+  late MockFirebaseAuth mockAuth;
+  late AuthViewModel authViewModel;
+
+  setUp(() {
+    mockAuth = MockFirebaseAuth();
+    authViewModel = AuthViewModel(auth: mockAuth);
+  });
+
+  tearDown(() {
+    mockAuth.dispose();
+  });
+
+  group('AuthViewModel._parseFirebaseError indirect tests', () {
+    test('returns "Something went wrong. Please try again." for non-FirebaseAuthException', () async {
+      mockAuth.errorToThrow = Exception('Generic Error');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Something went wrong. Please try again.');
+      }
+    });
+
+    test('returns correct message for "user-not-found"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'user-not-found');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'No account found with this email.');
+      }
+    });
+
+    test('returns correct message for "wrong-password"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'wrong-password');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Incorrect password. Please try again.');
+      }
+    });
+
+    test('returns correct message for "email-already-in-use"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'email-already-in-use');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'An account already exists with this email.');
+      }
+    });
+
+    test('returns correct message for "weak-password"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'weak-password');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Password is too weak. Use at least 6 characters.');
+      }
+    });
+
+    test('returns correct message for "invalid-email"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'invalid-email');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Please enter a valid email address.');
+      }
+    });
+
+    test('returns correct message for "too-many-requests"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'too-many-requests');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Too many attempts. Please try again later.');
+      }
+    });
+
+    test('returns correct message for "invalid-credential"', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'invalid-credential');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Invalid email or password.');
+      }
+    });
+
+    test('returns exception message or default for unknown code', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'unknown-code', message: 'Some specific error message.');
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Some specific error message.');
+      }
+    });
+
+    test('returns fallback default for unknown code with no message', () async {
+      mockAuth.errorToThrow = FakeFirebaseAuthException(code: 'unknown-code'); // no message
+
+      try {
+        await authViewModel.login('test@example.com', 'password');
+        fail('Should throw an exception');
+      } catch (e) {
+        expect(e, 'Authentication failed.');
+      }
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The private method `AuthViewModel._parseFirebaseError` was completely untested. It is used to convert internal `FirebaseAuthException` errors into user-friendly strings. 

📊 **Coverage:** What scenarios are now tested
This PR refactors `AuthViewModel` to accept an injected `FirebaseAuth` instance, allowing tests to safely use a manual `MockFirebaseAuth`. Indirect tests have been added via the `login` method to ensure all possible Firebase error states return the correct string.
- Tested: generic exceptions
- Tested `user-not-found`, `wrong-password`, `email-already-in-use`, `weak-password`, `invalid-email`, `too-many-requests`, `invalid-credential`
- Tested fallback `e.message` vs default

✨ **Result:** The improvement in test coverage
We now have full coverage for `AuthViewModel._parseFirebaseError`, increasing confidence in the reliability of our authentication-related error messages.

---
*PR created automatically by Jules for task [6924380759411485027](https://jules.google.com/task/6924380759411485027) started by @manupawickramasinghe*