### PR TITLE
🔒 [Security] Fix unencrypted HTTP traffic in LmsDataService

### DIFF
--- a/lib/studies/lms/data_service.dart
+++ b/lib/studies/lms/data_service.dart
@@ -25,7 +25,7 @@ class Video {
 }
 
 class LmsDataService {
-  final String baseUrl = 'http://localhost:5000';
+  final String baseUrl = 'https://localhost:5000';
   static String? _authToken;
 
   /// Authenticates the user and retrieves a JWT token.


### PR DESCRIPTION
🎯 **What:** Updated the `baseUrl` in `LmsDataService` (`lib/studies/lms/data_service.dart`) to use `https://localhost:5000` instead of `http://localhost:5000`.

⚠️ **Risk:** Sending data over unencrypted HTTP traffic leaves API communication (including sensitive information like user credentials and authentication tokens) exposed to man-in-the-middle attacks and snooping.

🛡️ **Solution:** Switched the protocol for the base URL to HTTPS to enforce encrypted communication with the backend.

---
*PR created automatically by Jules for task [8320912034626667694](https://jules.google.com/task/8320912034626667694) started by @manupawickramasinghe*