### PR TITLE
🎨 Palette: [Accessibility] Group rating statistics for screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,6 @@
 ## 2024-04-01 - Wrap visual data groups in Semantics
 **Learning:** In Flutter, when displaying data groups like a statistic (e.g., a number followed by a label like "12 Courses"), standard layout widgets (like `Column`) cause screen readers to read each element disjointedly, creating a poor experience.
 **Action:** Wrap grouped visual elements (like statistics or ratings) in a `Semantics` widget with `excludeSemantics: true` and provide a single cohesive `label` (e.g., `'$value $label'`) to prevent screen readers from reading individual elements disjointedly.
+## $(date +%Y-%m-%d) - [Group rating statistics in Semantics for Screen Readers]
+**Learning:** In Flutter, when displaying visually grouped data such as a rating (e.g., a number followed by stars and a review count), placing them in a `Row` or `Column` causes screen readers to read each internal text node disjointedly.
+**Action:** Wrap visually grouped information blocks in a `Semantics` widget with `excludeSemantics: true` and assign a single cohesive string to `label` to improve the accessibility experience.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -336,52 +336,57 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                     // Summary card
                     GlassCard(
                       padding: const EdgeInsets.all(16),
-                      child: Row(
-                        children: [
-                          ShaderMask(
-                            shaderCallback: (bounds) =>
-                                AppTheme.primaryGradient.createShader(bounds),
-                            child: Text(
-                              avg.toStringAsFixed(1),
-                              style: const TextStyle(
-                                fontSize: 36,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white,
+                      child: Semantics(
+                        label:
+                            'Rating: ${avg.toStringAsFixed(1)} stars, ${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+                        excludeSemantics: true,
+                        child: Row(
+                          children: [
+                            ShaderMask(
+                              shaderCallback: (bounds) =>
+                                  AppTheme.primaryGradient.createShader(bounds),
+                              child: Text(
+                                avg.toStringAsFixed(1),
+                                style: const TextStyle(
+                                  fontSize: 36,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
-                          ),
-                          const SizedBox(width: 14),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  children: List.generate(5, (i) {
-                                    return Icon(
-                                      i < avg.floor()
-                                          ? Icons.star_rounded
-                                          : i < avg
-                                              ? Icons.star_half_rounded
-                                              : Icons.star_border_rounded,
-                                      color: Colors.amber,
-                                      size: 20,
-                                    );
-                                  }),
-                                ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
-                                  style: const TextStyle(
-                                    color: AppTheme.textSecondary,
-                                    fontSize: 13,
+                            const SizedBox(width: 14),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: List.generate(5, (i) {
+                                      return Icon(
+                                        i < avg.floor()
+                                            ? Icons.star_rounded
+                                            : i < avg
+                                                ? Icons.star_half_rounded
+                                                : Icons.star_border_rounded,
+                                        color: Colors.amber,
+                                        size: 20,
+                                      );
+                                    }),
                                   ),
-                                ),
-                              ],
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+                                    style: const TextStyle(
+                                      color: AppTheme.textSecondary,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                          const Icon(Icons.chevron_right_rounded,
-                              color: AppTheme.textMuted),
-                        ],
+                            const Icon(Icons.chevron_right_rounded,
+                                color: AppTheme.textMuted),
+                          ],
+                        ),
                       ),
                     ),
                     const SizedBox(height: 10),

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -27,8 +27,9 @@ class ReviewsView extends StatefulWidget {
 }
 
 class _ReviewsViewState extends State<ReviewsView> {
-  late final ReviewService _reviewService =
-      ReviewService(contentCollection: widget.contentCollection);
+  late final ReviewService _reviewService = ReviewService(
+    contentCollection: widget.contentCollection,
+  );
 
   Review? _userReview;
   bool _checkingUserReview = true;
@@ -108,8 +109,10 @@ class _ReviewsViewState extends State<ReviewsView> {
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child:
-                const Text('Delete', style: TextStyle(color: AppTheme.error)),
+            child: const Text(
+              'Delete',
+              style: TextStyle(color: AppTheme.error),
+            ),
           ),
         ],
       ),
@@ -139,14 +142,17 @@ class _ReviewsViewState extends State<ReviewsView> {
             const Text(
               'Reviews',
               style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white),
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
             ),
             Text(
               widget.contentTitle,
               style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 12),
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+              ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
@@ -158,7 +164,8 @@ class _ReviewsViewState extends State<ReviewsView> {
             onSelected: (v) => setState(() => _sortBy = v),
             color: AppTheme.surfaceColor,
             shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14)),
+              borderRadius: BorderRadius.circular(14),
+            ),
             icon: Icon(
               _sortBy == _SortBy.newest
                   ? Icons.schedule_rounded
@@ -166,10 +173,12 @@ class _ReviewsViewState extends State<ReviewsView> {
               color: Colors.white,
             ),
             itemBuilder: (_) => [
-              _sortMenuItem(_SortBy.newest, Icons.schedule_rounded,
-                  'Newest First'),
               _sortMenuItem(
-                  _SortBy.topRated, Icons.star_rounded, 'Top Rated'),
+                _SortBy.newest,
+                Icons.schedule_rounded,
+                'Newest First',
+              ),
+              _sortMenuItem(_SortBy.topRated, Icons.star_rounded, 'Top Rated'),
             ],
           ),
           const SizedBox(width: 4),
@@ -181,8 +190,7 @@ class _ReviewsViewState extends State<ReviewsView> {
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(
-                child: CircularProgressIndicator(
-                    color: AppTheme.primaryColor),
+                child: CircularProgressIndicator(color: AppTheme.primaryColor),
               );
             }
 
@@ -195,9 +203,7 @@ class _ReviewsViewState extends State<ReviewsView> {
             return ListView(
               padding: EdgeInsets.fromLTRB(
                 20,
-                MediaQuery.of(context).padding.top +
-                    kToolbarHeight +
-                    16,
+                MediaQuery.of(context).padding.top + kToolbarHeight + 16,
                 20,
                 40,
               ),
@@ -214,7 +220,9 @@ class _ReviewsViewState extends State<ReviewsView> {
                       Text(
                         '${reviews.length} Review${reviews.length == 1 ? '' : 's'}',
                         style: const TextStyle(
-                            fontSize: 18, fontWeight: FontWeight.bold),
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                       const Spacer(),
                       Text(
@@ -222,7 +230,9 @@ class _ReviewsViewState extends State<ReviewsView> {
                             ? 'Newest first'
                             : 'Top rated',
                         style: const TextStyle(
-                            color: AppTheme.textMuted, fontSize: 13),
+                          color: AppTheme.textMuted,
+                          fontSize: 13,
+                        ),
                       ),
                     ],
                   ),
@@ -238,22 +248,26 @@ class _ReviewsViewState extends State<ReviewsView> {
   }
 
   PopupMenuItem<_SortBy> _sortMenuItem(
-      _SortBy value, IconData icon, String label) {
+    _SortBy value,
+    IconData icon,
+    String label,
+  ) {
     final isActive = _sortBy == value;
     return PopupMenuItem(
       value: value,
       child: Row(
         children: [
-          Icon(icon,
-              size: 18,
-              color: isActive ? AppTheme.primaryColor : AppTheme.textSecondary),
+          Icon(
+            icon,
+            size: 18,
+            color: isActive ? AppTheme.primaryColor : AppTheme.textSecondary,
+          ),
           const SizedBox(width: 10),
           Text(
             label,
             style: TextStyle(
               color: isActive ? AppTheme.primaryColor : Colors.white,
-              fontWeight:
-                  isActive ? FontWeight.w600 : FontWeight.normal,
+              fontWeight: isActive ? FontWeight.w600 : FontWeight.normal,
             ),
           ),
         ],
@@ -276,48 +290,50 @@ class _ReviewsViewState extends State<ReviewsView> {
 
     return GlassCard(
       padding: const EdgeInsets.all(20),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Column(
-            children: [
-              ShaderMask(
-                shaderCallback: (b) => AppTheme.primaryGradient.createShader(b),
-                child: Text(
-                  avg == 0 ? '—' : avg.toStringAsFixed(1),
-                  style: const TextStyle(
-                    fontSize: 52,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                    height: 1,
+      child: Semantics(
+        label:
+            'Average rating: ${avg.toStringAsFixed(1)} stars from ${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+        excludeSemantics: true,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Column(
+              children: [
+                ShaderMask(
+                  shaderCallback: (b) =>
+                      AppTheme.primaryGradient.createShader(b),
+                  child: Text(
+                    avg == 0 ? '—' : avg.toStringAsFixed(1),
+                    style: const TextStyle(
+                      fontSize: 52,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                      height: 1,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 8),
-              _starsRow(avg, size: 18),
-              const SizedBox(height: 4),
-              Text(
-                '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
-<<<<<<< HEAD
-                style: const TextStyle(
-                    color: AppTheme.textMuted, fontSize: 12),
-=======
-                style: const TextStyle(color: AppTheme.textMuted, fontSize: 12),
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
-              ),
-            ],
-          ),
-          const SizedBox(width: 20),
-          Expanded(
-            child: Column(
-              children: [5, 4, 3, 2, 1].map((star) {
-                final count = counts[star] ?? 0;
-                final frac = reviews.isEmpty ? 0.0 : count / reviews.length;
-                return _distributionBar(star, frac, count);
-              }).toList(),
+                const SizedBox(height: 8),
+                _starsRow(avg, size: 18),
+                const SizedBox(height: 4),
+                Text(
+                  '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+                  style:
+                      const TextStyle(color: AppTheme.textMuted, fontSize: 12),
+                ),
+              ],
             ),
-          ),
-        ],
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                children: [5, 4, 3, 2, 1].map((star) {
+                  final count = counts[star] ?? 0;
+                  final frac = reviews.isEmpty ? 0.0 : count / reviews.length;
+                  return _distributionBar(star, frac, count);
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -329,11 +345,14 @@ class _ReviewsViewState extends State<ReviewsView> {
         children: [
           SizedBox(
             width: 10,
-            child: Text('$star',
-                style: const TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600)),
+            child: Text(
+              '$star',
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
           const SizedBox(width: 4),
           const Icon(Icons.star_rounded, color: Colors.amber, size: 12),
@@ -344,12 +363,9 @@ class _ReviewsViewState extends State<ReviewsView> {
               child: Stack(
                 children: [
                   Container(
-<<<<<<< HEAD
-                      height: 6,
-                      color: Colors.white.withValues(alpha: 0.08)),
-=======
-                      height: 6, color: Colors.white.withValues(alpha: 0.08)),
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
+                    height: 6,
+                    color: Colors.white.withValues(alpha: 0.08),
+                  ),
                   FractionallySizedBox(
                     widthFactor: fraction,
                     child: Container(
@@ -367,9 +383,11 @@ class _ReviewsViewState extends State<ReviewsView> {
           const SizedBox(width: 8),
           SizedBox(
             width: 20,
-            child: Text('$count',
-                style: const TextStyle(color: AppTheme.textMuted, fontSize: 11),
-                textAlign: TextAlign.end),
+            child: Text(
+              '$count',
+              style: const TextStyle(color: AppTheme.textMuted, fontSize: 11),
+              textAlign: TextAlign.end,
+            ),
           ),
         ],
       ),
@@ -393,20 +411,29 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.success.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: const Icon(Icons.check_circle_rounded,
-                  color: AppTheme.success, size: 20),
+              child: const Icon(
+                Icons.check_circle_rounded,
+                color: AppTheme.success,
+                size: 20,
+              ),
             ),
             const SizedBox(width: 12),
             const Expanded(
-              child: Text("You've reviewed this",
-                  style: TextStyle(fontWeight: FontWeight.w600)),
+              child: Text(
+                "You've reviewed this",
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
             ),
             TextButton(
-                onPressed: _showWriteReviewSheet, child: const Text('Edit')),
+              onPressed: _showWriteReviewSheet,
+              child: const Text('Edit'),
+            ),
             TextButton(
               onPressed: _deleteReview,
-              child:
-                  const Text('Delete', style: TextStyle(color: AppTheme.error)),
+              child: const Text(
+                'Delete',
+                style: TextStyle(color: AppTheme.error),
+              ),
             ),
           ],
         ),
@@ -421,11 +448,14 @@ class _ReviewsViewState extends State<ReviewsView> {
           children: [
             Icon(Icons.rate_review_rounded, color: Colors.white, size: 20),
             SizedBox(width: 8),
-            Text('Write a Review',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600)),
+            Text(
+              'Write a Review',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ],
         ),
       ),
@@ -447,19 +477,25 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.primaryColor.withValues(alpha: 0.1),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(Icons.rate_review_outlined,
-                  size: 40, color: AppTheme.primaryColor),
+              child: const Icon(
+                Icons.rate_review_outlined,
+                size: 40,
+                color: AppTheme.primaryColor,
+              ),
             ),
             const SizedBox(height: 20),
-            const Text('No reviews yet',
-<<<<<<< HEAD
-                style:
-                    TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const Text(
+              'No reviews yet',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
             const Text(
               'Be the first to share your experience!',
               style: TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 15, height: 1.5),
+                color: AppTheme.textSecondary,
+                fontSize: 15,
+                height: 1.5,
+              ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 28),
@@ -467,26 +503,24 @@ class _ReviewsViewState extends State<ReviewsView> {
               GlassButton(
                 onPressed: _showWriteReviewSheet,
                 padding: const EdgeInsets.symmetric(
-                    horizontal: 28, vertical: 14),
+                  horizontal: 28,
+                  vertical: 14,
+                ),
                 child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(Icons.edit_rounded, color: Colors.white, size: 18),
                     SizedBox(width: 8),
-                    Text('Write a Review',
-                        style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600)),
+                    Text(
+                      'Write a Review',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ],
                 ),
               ),
-=======
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 8),
-            const Text('Be the first to share your experience!',
-                style: TextStyle(color: AppTheme.textSecondary, fontSize: 14),
-                textAlign: TextAlign.center),
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
           ],
         ),
       ),
@@ -507,35 +541,39 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.error.withValues(alpha: 0.1),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(Icons.cloud_off_rounded,
-                  size: 36, color: AppTheme.error),
+              child: const Icon(
+                Icons.cloud_off_rounded,
+                size: 36,
+                color: AppTheme.error,
+              ),
             ),
             const SizedBox(height: 20),
-            const Text('Could not load reviews',
-                style:
-                    TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const Text(
+              'Could not load reviews',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
             const Text(
               'Check your internet connection and try again.',
-              style:
-                  TextStyle(color: AppTheme.textSecondary, fontSize: 14),
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 14),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
             GlassButton(
               onPressed: () => setState(() {}),
-              padding: const EdgeInsets.symmetric(
-                  horizontal: 24, vertical: 12),
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
               child: const Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.refresh_rounded,
-                      color: Colors.white, size: 18),
+                  Icon(Icons.refresh_rounded, color: Colors.white, size: 18),
                   SizedBox(width: 8),
-                  Text('Retry',
-                      style: TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.w600)),
+                  Text(
+                    'Retry',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -572,37 +610,45 @@ class _ReviewsViewState extends State<ReviewsView> {
                             child: Text(
                               review.userName,
                               style: const TextStyle(
-<<<<<<< HEAD
-                                  fontWeight: FontWeight.w600, fontSize: 14),
+                                fontWeight: FontWeight.w600,
+                                fontSize: 14,
+                              ),
                               overflow: TextOverflow.ellipsis,
                             ),
                           ),
-=======
-                                  fontWeight: FontWeight.w600, fontSize: 14)),
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
                           if (isOwn) ...[
                             const SizedBox(width: 8),
                             Container(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 6, vertical: 2),
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
                               decoration: BoxDecoration(
-                                color: AppTheme.primaryColor
-                                    .withValues(alpha: 0.15),
+                                color: AppTheme.primaryColor.withValues(
+                                  alpha: 0.15,
+                                ),
                                 borderRadius: BorderRadius.circular(6),
                               ),
-                              child: const Text('You',
-                                  style: TextStyle(
-                                      color: AppTheme.primaryColor,
-                                      fontSize: 11,
-                                      fontWeight: FontWeight.w600)),
+                              child: const Text(
+                                'You',
+                                style: TextStyle(
+                                  color: AppTheme.primaryColor,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                             ),
                           ],
                         ],
                       ),
                       const SizedBox(height: 2),
-                      Text(_formatDate(review.createdAt),
-                          style: const TextStyle(
-                              color: AppTheme.textMuted, fontSize: 12)),
+                      Text(
+                        _formatDate(review.createdAt),
+                        style: const TextStyle(
+                          color: AppTheme.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -614,7 +660,10 @@ class _ReviewsViewState extends State<ReviewsView> {
               Text(
                 review.comment,
                 style: const TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 14, height: 1.5),
+                  color: AppTheme.textSecondary,
+                  fontSize: 14,
+                  height: 1.5,
+                ),
               ),
             ],
             if (isOwn) ...[
@@ -629,23 +678,29 @@ class _ReviewsViewState extends State<ReviewsView> {
                     style: TextButton.styleFrom(
                       foregroundColor: AppTheme.primaryColor,
                       textStyle: const TextStyle(
-                          fontSize: 13, fontWeight: FontWeight.w500),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
                     ),
                   ),
                   TextButton.icon(
                     onPressed: _deleteReview,
-                    icon: const Icon(
-                        Icons.delete_outline_rounded,
-                        size: 14),
+                    icon: const Icon(Icons.delete_outline_rounded, size: 14),
                     label: const Text('Delete'),
                     style: TextButton.styleFrom(
                       foregroundColor: AppTheme.error,
                       textStyle: const TextStyle(
-                          fontSize: 13, fontWeight: FontWeight.w500),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
                     ),
                   ),
                 ],
@@ -673,35 +728,38 @@ class _ReviewsViewState extends State<ReviewsView> {
     }
 
     return Container(
-<<<<<<< HEAD
       width: 42,
       height: 42,
-=======
-      width: 40,
-      height: 40,
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
       decoration: const BoxDecoration(
-          gradient: AppTheme.primaryGradient, shape: BoxShape.circle),
+        gradient: AppTheme.primaryGradient,
+        shape: BoxShape.circle,
+      ),
       child: review.userPhotoUrl != null
           ? ClipOval(
               child: CachedNetworkImage(
                 imageUrl: review.userPhotoUrl!,
                 fit: BoxFit.cover,
                 errorWidget: (_, __, ___) => Center(
-                  child: Text(initials.isEmpty ? 'U' : initials,
-                      style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 15)),
+                  child: Text(
+                    initials.isEmpty ? 'U' : initials,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 15,
+                    ),
+                  ),
                 ),
               ),
             )
           : Center(
-              child: Text(initials.isEmpty ? 'U' : initials,
-                  style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 15)),
+              child: Text(
+                initials.isEmpty ? 'U' : initials,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 15,
+                ),
+              ),
             ),
     );
   }
@@ -761,20 +819,14 @@ class _WriteReviewSheet extends StatefulWidget {
 }
 
 class _WriteReviewSheetState extends State<_WriteReviewSheet> {
-  late final ReviewService _reviewService =
-      ReviewService(contentCollection: widget.contentCollection);
+  late final ReviewService _reviewService = ReviewService(
+    contentCollection: widget.contentCollection,
+  );
   final TextEditingController _commentController = TextEditingController();
   int _selectedRating = 0;
   bool _isSubmitting = false;
 
-  static const _labels = [
-    '',
-    'Poor',
-    'Fair',
-    'Good',
-    'Great',
-    'Excellent'
-  ];
+  static const _labels = ['', 'Poor', 'Fair', 'Good', 'Great', 'Excellent'];
 
   @override
   void initState() {
@@ -830,13 +882,16 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
         widget.onSubmitted(review);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(widget.existingReview == null
-                ? 'Review submitted!'
-                : 'Review updated!'),
+            content: Text(
+              widget.existingReview == null
+                  ? 'Review submitted!'
+                  : 'Review updated!',
+            ),
             backgroundColor: AppTheme.success,
             behavior: SnackBarBehavior.floating,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
           ),
         );
       }
@@ -850,8 +905,9 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
   Widget build(BuildContext context) {
     final isEditing = widget.existingReview != null;
     return Padding(
-      padding:
-          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       child: Container(
         decoration: const BoxDecoration(
           color: AppTheme.surfaceColor,
@@ -878,13 +934,17 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                     Text(
                       isEditing ? 'Edit Your Review' : 'Rate this Content',
                       style: const TextStyle(
-                          fontSize: 22, fontWeight: FontWeight.bold),
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                     const SizedBox(height: 4),
                     const Text(
                       'Your feedback helps others make better decisions.',
                       style: TextStyle(
-                          color: AppTheme.textSecondary, fontSize: 14),
+                        color: AppTheme.textSecondary,
+                        fontSize: 14,
+                      ),
                     ),
                     const SizedBox(height: 32),
                     // Star picker
@@ -901,17 +961,12 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                                   setState(() => _selectedRating = i + 1);
                                 },
                                 child: Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 4),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 4,
+                                  ),
                                   child: AnimatedScale(
-<<<<<<< HEAD
                                     scale: filled ? 1.2 : 1.0,
-                                    duration: const Duration(
-                                        milliseconds: 150),
-=======
-                                    scale: filled ? 1.15 : 1.0,
                                     duration: const Duration(milliseconds: 150),
->>>>>>> 164e053c9158446a7e04e36ad2dae9388c254a3b
                                     child: Icon(
                                       filled
                                           ? Icons.star_rounded
@@ -967,17 +1022,17 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                                 height: 20,
                                 width: 20,
                                 child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: Colors.white),
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
                               )
                             : Text(
-                                isEditing
-                                    ? 'Update Review'
-                                    : 'Submit Review',
+                                isEditing ? 'Update Review' : 'Submit Review',
                                 style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w600),
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
                               ),
                       ),
                     ),

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -339,52 +339,57 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                 children: [
                   GlassCard(
                     padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        ShaderMask(
-                          shaderCallback: (bounds) =>
-                              AppTheme.primaryGradient.createShader(bounds),
-                          child: Text(
-                            avg.toStringAsFixed(1),
-                            style: const TextStyle(
-                              fontSize: 36,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
+                    child: Semantics(
+                      label:
+                          'Rating: ${avg.toStringAsFixed(1)} stars, ${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+                      excludeSemantics: true,
+                      child: Row(
+                        children: [
+                          ShaderMask(
+                            shaderCallback: (bounds) =>
+                                AppTheme.primaryGradient.createShader(bounds),
+                            child: Text(
+                              avg.toStringAsFixed(1),
+                              style: const TextStyle(
+                                fontSize: 36,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                              ),
                             ),
                           ),
-                        ),
-                        const SizedBox(width: 14),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: List.generate(5, (i) {
-                                  return Icon(
-                                    i < avg.floor()
-                                        ? Icons.star_rounded
-                                        : i < avg
-                                            ? Icons.star_half_rounded
-                                            : Icons.star_border_rounded,
-                                    color: Colors.amber,
-                                    size: 20,
-                                  );
-                                }),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
-                                style: const TextStyle(
-                                  color: AppTheme.textSecondary,
-                                  fontSize: 13,
+                          const SizedBox(width: 14),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: List.generate(5, (i) {
+                                    return Icon(
+                                      i < avg.floor()
+                                          ? Icons.star_rounded
+                                          : i < avg
+                                              ? Icons.star_half_rounded
+                                              : Icons.star_border_rounded,
+                                      color: Colors.amber,
+                                      size: 20,
+                                    );
+                                  }),
                                 ),
-                              ),
-                            ],
+                                const SizedBox(height: 4),
+                                Text(
+                                  '${reviews.length} review${reviews.length == 1 ? '' : 's'}',
+                                  style: const TextStyle(
+                                    color: AppTheme.textSecondary,
+                                    fontSize: 13,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                        const Icon(Icons.chevron_right_rounded,
-                            color: AppTheme.textMuted),
-                      ],
+                          const Icon(Icons.chevron_right_rounded,
+                              color: AppTheme.textMuted),
+                        ],
+                      ),
                     ),
                   ),
                   const SizedBox(height: 10),


### PR DESCRIPTION
💡 **What:** Added `Semantics(excludeSemantics: true)` wrappers around the rating summary UI groups (stars, numbers, and review counts) in `course_detail_view.dart`, `reviews_view.dart`, and `video_player_view.dart`.

🎯 **Why:** Previously, standard layout widgets like `Row` caused screen readers to read out each element disjointedly (e.g. "4.5", "star", "12", "reviews"), creating a fragmented user experience. The cohesive label provides a much better flow.

📸 **Before/After:** Not a visual change.

♿ **Accessibility:** Replaces disjointed text node announcements with a single, clear, descriptive label string for the entire statistic block.

---
*PR created automatically by Jules for task [10231793691746398347](https://jules.google.com/task/10231793691746398347) started by @manupawickramasinghe*