### PR TITLE
⚡ Bolt: [performance improvement] Optimize iterable allocation in Reviews View

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,6 @@
 ## 2024-05-27 - Flutter .map() Iterable Allocation in Widget Trees
 **Learning:** In Flutter, generating widget lists inside the `build` method using spread operators combined with `.map()` (e.g., `...reviews.take(2).map((r) => _buildInlineReviewCard(r))`) allocates intermediate Iterable objects and closures. While seemingly minor, this pattern creates unnecessary garbage collection pressure when the widget tree rebuilds, degrading performance.
 **Action:** Always replace `...collection.map(...)` patterns with Dart's collection `for` loop (e.g., `for (final r in collection) _buildInlineReviewCard(r)`). This constructs the widget list directly in place without creating any intermediate iterable objects, optimizing rendering performance.
+## 2024-05-28 - Flutter .map() and Spread Operator Overhead
+**Learning:** In Flutter/Dart, using the spread operator on a mapped iterable (e.g., `...items.map(...)`) inside a widget's `build` method allocates an intermediate `MappedIterable` object and its associated iterator closures on every build frame. This causes unnecessary garbage collection pressure.
+**Action:** Always replace the `...collection.map(...)` pattern with a collection `for` loop (e.g., `for (final item in items) ...`) inside lists and widget trees to avoid intermediate object allocations and improve rendering performance.

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -227,7 +227,7 @@ class _ReviewsViewState extends State<ReviewsView> {
                     ],
                   ),
                   const SizedBox(height: 14),
-                  ...reviews.map(_buildReviewCard),
+                  for (final review in reviews) _buildReviewCard(review),
                 ],
               ],
             );


### PR DESCRIPTION
💡 **What:** Replaced the spread operator and `.map()` method (`...reviews.map(...)`) with a collection `for` loop (`for (final review in reviews)`) inside `lib/views/course/reviews_view.dart`.
🎯 **Why:** In Dart, using `.map()` creates an intermediate `MappedIterable` object and associated closures. When used inside a Flutter `build` method (which can be called frequently), this causes unnecessary object allocations and increases garbage collection overhead.
📊 **Impact:** Reduces memory allocations during rendering. While the visual impact is the same, this is a standard Flutter best practice to prevent GC stutter during widget rebuilds.
🔬 **Measurement:** Code health improvement, benchmarkable by observing reduced heap allocations in Dart DevTools during UI interactions.

---
*PR created automatically by Jules for task [12082962463402670283](https://jules.google.com/task/12082962463402670283) started by @manupawickramasinghe*