### PR TITLE
🎨 Palette: Make learning tabs interactive and stateful

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-04-01 - Wrap visual data groups in Semantics
 **Learning:** In Flutter, when displaying data groups like a statistic (e.g., a number followed by a label like "12 Courses"), standard layout widgets (like `Column`) cause screen readers to read each element disjointedly, creating a poor experience.
 **Action:** Wrap grouped visual elements (like statistics or ratings) in a `Semantics` widget with `excludeSemantics: true` and provide a single cohesive `label` (e.g., `'$value $label'`) to prevent screen readers from reading individual elements disjointedly.
+
+## 2024-05-31 - [Interactive Tabs and Dynamic Content]
+**Learning:** Found that custom tab-like navigation elements in Flutter are often built as static `Container`s within `StatelessWidget`s, meaning they lack visual feedback (ripple effect) when tapped, and the surrounding view doesn't update its content based on the active tab, resulting in a confusing UX.
+**Action:** When implementing or fixing custom tabs, convert the parent to a `StatefulWidget` to track the active index, wrap the tab items in `Material` and `InkWell` for visual feedback, and ensure the content view dynamically updates its state based on the selected tab index.

--- a/lib/views/my_learning/my_learning_view.dart
+++ b/lib/views/my_learning/my_learning_view.dart
@@ -2,10 +2,17 @@ import 'package:flutter/material.dart';
 import '../../core/app_theme.dart';
 import '../../core/glass_widgets.dart';
 
-class MyLearningView extends StatelessWidget {
+class MyLearningView extends StatefulWidget {
   final VoidCallback? onExplore;
 
   const MyLearningView({super.key, this.onExplore});
+
+  @override
+  State<MyLearningView> createState() => _MyLearningViewState();
+}
+
+class _MyLearningViewState extends State<MyLearningView> {
+  int _selectedTabIndex = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +43,9 @@ class MyLearningView extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
                 child: Row(
                   children: [
-                    _buildTab('In Progress', true),
-                    _buildTab('Completed', false),
-                    _buildTab('Saved', false),
+                    _buildTab('In Progress', 0),
+                    _buildTab('Completed', 1),
+                    _buildTab('Saved', 2),
                   ],
                 ),
               ),
@@ -51,21 +58,36 @@ class MyLearningView extends StatelessWidget {
     );
   }
 
-  Widget _buildTab(String label, bool isActive) {
+  Widget _buildTab(String label, int index) {
+    final isActive = _selectedTabIndex == index;
+
     return Expanded(
       child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 12),
         decoration: BoxDecoration(
           gradient: isActive ? AppTheme.primaryGradient : null,
           borderRadius: BorderRadius.circular(10),
         ),
-        child: Text(
-          label,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: isActive ? Colors.white : AppTheme.textSecondary,
-            fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
-            fontSize: 14,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(10),
+            onTap: () {
+              setState(() {
+                _selectedTabIndex = index;
+              });
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Text(
+                label,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: isActive ? Colors.white : AppTheme.textSecondary,
+                  fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                  fontSize: 14,
+                ),
+              ),
+            ),
           ),
         ),
       ),
@@ -73,6 +95,29 @@ class MyLearningView extends StatelessWidget {
   }
 
   Widget _buildEmptyState() {
+    IconData icon;
+    String title;
+    String subtitle;
+
+    switch (_selectedTabIndex) {
+      case 1:
+        icon = Icons.emoji_events_rounded;
+        title = 'No Completed Courses';
+        subtitle = 'Keep learning! Your completed\ncourses will appear here.';
+        break;
+      case 2:
+        icon = Icons.bookmark_rounded;
+        title = 'No Saved Courses';
+        subtitle = 'Save courses you are interested in\nto find them quickly later.';
+        break;
+      case 0:
+      default:
+        icon = Icons.school_rounded;
+        title = 'Start Learning';
+        subtitle = 'Your enrolled courses and progress\nwill appear here.';
+        break;
+    }
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -86,21 +131,21 @@ class MyLearningView extends StatelessWidget {
                 color: AppTheme.secondaryColor.withValues(alpha: 0.12),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(
-                Icons.school_rounded,
+              child: Icon(
+                icon,
                 size: 44,
                 color: AppTheme.secondaryColor,
               ),
             ),
             const SizedBox(height: 24),
-            const Text(
-              'Start Learning',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            Text(
+              title,
+              style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
-            const Text(
-              'Your enrolled courses and progress\nwill appear here.',
-              style: TextStyle(
+            Text(
+              subtitle,
+              style: const TextStyle(
                 color: AppTheme.textSecondary,
                 fontSize: 15,
                 height: 1.5,
@@ -109,7 +154,7 @@ class MyLearningView extends StatelessWidget {
             ),
             const SizedBox(height: 28),
             GlassButton(
-              onPressed: onExplore,
+              onPressed: widget.onExplore,
               padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
               child: const Row(
                 mainAxisSize: MainAxisSize.min,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hackston_lms/views/my_learning/my_learning_view.dart';
+
+void main() {
+  testWidgets('MyLearningView tabs interaction updates empty state', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: MyLearningView(),
+      ),
+    ));
+
+    // Verify initial state (In Progress tab)
+    expect(find.text('Start Learning'), findsOneWidget);
+    expect(find.text('Your enrolled courses and progress\nwill appear here.'), findsOneWidget);
+    expect(find.byIcon(Icons.school_rounded), findsOneWidget);
+
+    // Tap the 'Completed' tab
+    await tester.tap(find.text('Completed'));
+    await tester.pumpAndSettle();
+
+    // Verify updated state for Completed tab
+    expect(find.text('No Completed Courses'), findsOneWidget);
+    expect(find.text('Keep learning! Your completed\ncourses will appear here.'), findsOneWidget);
+    expect(find.byIcon(Icons.emoji_events_rounded), findsOneWidget);
+
+    // Tap the 'Saved' tab
+    await tester.tap(find.text('Saved'));
+    await tester.pumpAndSettle();
+
+    // Verify updated state for Saved tab
+    expect(find.text('No Saved Courses'), findsOneWidget);
+    expect(find.text('Save courses you are interested in\nto find them quickly later.'), findsOneWidget);
+    expect(find.byIcon(Icons.bookmark_rounded), findsOneWidget);
+  });
+}


### PR DESCRIPTION
💡 **What:** Converted `MyLearningView` to a `StatefulWidget`, added `Material` and `InkWell` to the tab items for ripple feedback, and updated the empty state to dynamically reflect the selected tab ("In Progress", "Completed", "Saved").
🎯 **Why:** Previously, the tabs in the "My Learning" view were static `Container`s. Clicking them provided no visual feedback and did not change the content of the view, leading to a confusing and unresponsive user experience.
📸 **Before/After:** Before, clicking "Completed" did nothing. Now, it shows a ripple effect, highlights the tab, and updates the empty state below to show "No Completed Courses" with an appropriate icon and subtitle.
♿ **Accessibility:** Wrapping the tabs in `InkWell` implicitly adds button semantics, making them more recognizable to screen readers as interactive elements compared to static `Container`s.

---
*PR created automatically by Jules for task [10224911806759621011](https://jules.google.com/task/10224911806759621011) started by @manupawickramasinghe*