### PR TITLE
⚡ Bolt: Replace ListView with ListView.builder in ReviewsView for virtualization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,3 +57,7 @@
 
 **Learning:** Calling a stream getter method directly inside the `stream` parameter of a `StreamBuilder` causes the stream to be recreated on every widget rebuild. This leads to redundant subscriptions and unnecessary resource allocations, especially for things like Firestore listeners.
 **Action:** Always initialize the stream inside the `initState` of a StatefulWidget and pass the cached stream reference to the `StreamBuilder`. Remember to implement `didUpdateWidget` to recreate the stream if its dependencies change.
+## 2024-05-29 - Flutter ListView Eager Building Anti-Pattern
+
+**Learning:** Using `ListView` with a `children` list containing a `for` loop over potentially unbounded datasets (e.g., `for (final review in reviews) _buildReviewCard(review)`) eagerly builds all widgets at once. This completely destroys the virtualization benefits of list views, blocking the main UI thread during the initial render and consuming excessive memory as the dataset grows.
+**Action:** Always replace eagerly constructed `ListView` children with `ListView.builder` for potentially large datasets to ensure list items are only built dynamically as they scroll into view, maintaining smooth 60fps rendering and bounded memory usage.

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -202,42 +202,52 @@ class _ReviewsViewState extends State<ReviewsView> {
 
             final reviews = _sorted(snapshot.data ?? []);
 
-            return ListView(
+            // ⚡ Bolt: Use ListView.builder for potentially unbounded datasets to enable virtualization
+            // and prevent UI thread blocking during initial render.
+            return ListView.builder(
               padding: EdgeInsets.fromLTRB(
                 20,
                 MediaQuery.of(context).padding.top + kToolbarHeight + 16,
                 20,
                 40,
               ),
-              children: [
-                _buildRatingSummary(snapshot.data ?? []),
-                const SizedBox(height: 20),
-                if (!_checkingUserReview) _buildWriteReviewRow(),
-                const SizedBox(height: 20),
-                if (reviews.isEmpty)
-                  _buildEmptyState()
-                else ...[
-                  Row(
+              itemCount: reviews.isEmpty ? 1 : reviews.length + 1,
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        '${reviews.length} Review${reviews.length == 1 ? '' : 's'}',
-                        style: const TextStyle(
-                            fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-                      const Spacer(),
-                      Text(
-                        _sortBy == _SortBy.newest
-                            ? 'Newest first'
-                            : 'Top rated',
-                        style: const TextStyle(
-                            color: AppTheme.textMuted, fontSize: 13),
-                      ),
+                      _buildRatingSummary(snapshot.data ?? []),
+                      const SizedBox(height: 20),
+                      if (!_checkingUserReview) _buildWriteReviewRow(),
+                      const SizedBox(height: 20),
+                      if (reviews.isEmpty)
+                        _buildEmptyState()
+                      else ...[
+                        Row(
+                          children: [
+                            Text(
+                              '${reviews.length} Review${reviews.length == 1 ? '' : 's'}',
+                              style: const TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.bold),
+                            ),
+                            const Spacer(),
+                            Text(
+                              _sortBy == _SortBy.newest
+                                  ? 'Newest first'
+                                  : 'Top rated',
+                              style: const TextStyle(
+                                  color: AppTheme.textMuted, fontSize: 13),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 14),
+                      ],
                     ],
-                  ),
-                  const SizedBox(height: 14),
-                  for (final review in reviews) _buildReviewCard(review),
-                ],
-              ],
+                  );
+                }
+                return _buildReviewCard(reviews[index - 1]);
+              },
             );
           },
         ),

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+💡 What: Converted the eagerly built `ListView` in `ReviewsView` (which iterated over reviews with a `for` loop inside `children`) to use `ListView.builder`.
+🎯 Why: Eagerly building all list items at once destroys virtualization. For potentially unbounded datasets (like a list of reviews), this blocks the UI thread during the initial render and leads to unscalable memory consumption.
+📊 Impact: Significant reduction in memory usage and elimination of initial UI thread blocking when rendering large lists of reviews, maintaining smooth 60fps scrolling.
+🔬 Measurement: Verify that memory consumption remains stable regardless of the number of loaded reviews (using Flutter DevTools), and observe that the initial render time of `ReviewsView` is no longer proportional to the total number of reviews.


### PR DESCRIPTION
💡 What: Converted the eagerly built `ListView` in `ReviewsView` (which iterated over reviews with a `for` loop inside `children`) to use `ListView.builder`.
🎯 Why: Eagerly building all list items at once destroys virtualization. For potentially unbounded datasets (like a list of reviews), this blocks the UI thread during the initial render and leads to unscalable memory consumption.
📊 Impact: Significant reduction in memory usage and elimination of initial UI thread blocking when rendering large lists of reviews, maintaining smooth 60fps scrolling.
🔬 Measurement: Verify that memory consumption remains stable regardless of the number of loaded reviews (using Flutter DevTools), and observe that the initial render time of `ReviewsView` is no longer proportional to the total number of reviews.

---
*PR created automatically by Jules for task [10029980226933851494](https://jules.google.com/task/10029980226933851494) started by @manupawickramasinghe*