### PR TITLE
🎨 Palette: [UX improvement] Add tooltip to back button in reviews view

### DIFF
--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -27,8 +27,9 @@ class ReviewsView extends StatefulWidget {
 }
 
 class _ReviewsViewState extends State<ReviewsView> {
-  late final ReviewService _reviewService =
-      ReviewService(contentCollection: widget.contentCollection);
+  late final ReviewService _reviewService = ReviewService(
+    contentCollection: widget.contentCollection,
+  );
 
   Review? _userReview;
   bool _checkingUserReview = true;
@@ -120,8 +121,10 @@ class _ReviewsViewState extends State<ReviewsView> {
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child:
-                const Text('Delete', style: TextStyle(color: AppTheme.error)),
+            child: const Text(
+              'Delete',
+              style: TextStyle(color: AppTheme.error),
+            ),
           ),
         ],
       ),
@@ -142,6 +145,7 @@ class _ReviewsViewState extends State<ReviewsView> {
         backgroundColor: Colors.transparent,
         elevation: 0,
         leading: IconButton(
+          tooltip: 'Back',
           icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
           onPressed: () => Navigator.pop(context),
         ),
@@ -151,14 +155,17 @@ class _ReviewsViewState extends State<ReviewsView> {
             const Text(
               'Reviews',
               style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white),
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
             ),
             Text(
               widget.contentTitle,
-              style:
-                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+              ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
@@ -169,8 +176,9 @@ class _ReviewsViewState extends State<ReviewsView> {
             initialValue: _sortBy,
             onSelected: (v) => setState(() => _sortBy = v),
             color: AppTheme.surfaceColor,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
             icon: Icon(
               _sortBy == _SortBy.newest
                   ? Icons.schedule_rounded
@@ -179,7 +187,10 @@ class _ReviewsViewState extends State<ReviewsView> {
             ),
             itemBuilder: (_) => [
               _sortMenuItem(
-                  _SortBy.newest, Icons.schedule_rounded, 'Newest First'),
+                _SortBy.newest,
+                Icons.schedule_rounded,
+                'Newest First',
+              ),
               _sortMenuItem(_SortBy.topRated, Icons.star_rounded, 'Top Rated'),
             ],
           ),
@@ -229,7 +240,9 @@ class _ReviewsViewState extends State<ReviewsView> {
                             Text(
                               '${reviews.length} Review${reviews.length == 1 ? '' : 's'}',
                               style: const TextStyle(
-                                  fontSize: 18, fontWeight: FontWeight.bold),
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                             const Spacer(),
                             Text(
@@ -237,7 +250,9 @@ class _ReviewsViewState extends State<ReviewsView> {
                                   ? 'Newest first'
                                   : 'Top rated',
                               style: const TextStyle(
-                                  color: AppTheme.textMuted, fontSize: 13),
+                                color: AppTheme.textMuted,
+                                fontSize: 13,
+                              ),
                             ),
                           ],
                         ),
@@ -256,15 +271,20 @@ class _ReviewsViewState extends State<ReviewsView> {
   }
 
   PopupMenuItem<_SortBy> _sortMenuItem(
-      _SortBy value, IconData icon, String label) {
+    _SortBy value,
+    IconData icon,
+    String label,
+  ) {
     final isActive = _sortBy == value;
     return PopupMenuItem(
       value: value,
       child: Row(
         children: [
-          Icon(icon,
-              size: 18,
-              color: isActive ? AppTheme.primaryColor : AppTheme.textSecondary),
+          Icon(
+            icon,
+            size: 18,
+            color: isActive ? AppTheme.primaryColor : AppTheme.textSecondary,
+          ),
           const SizedBox(width: 10),
           Text(
             label,
@@ -341,11 +361,14 @@ class _ReviewsViewState extends State<ReviewsView> {
         children: [
           SizedBox(
             width: 10,
-            child: Text('$star',
-                style: const TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600)),
+            child: Text(
+              '$star',
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
           const SizedBox(width: 4),
           const Icon(Icons.star_rounded, color: Colors.amber, size: 12),
@@ -356,7 +379,9 @@ class _ReviewsViewState extends State<ReviewsView> {
               child: Stack(
                 children: [
                   Container(
-                      height: 6, color: Colors.white.withValues(alpha: 0.08)),
+                    height: 6,
+                    color: Colors.white.withValues(alpha: 0.08),
+                  ),
                   FractionallySizedBox(
                     widthFactor: fraction,
                     child: Container(
@@ -374,9 +399,11 @@ class _ReviewsViewState extends State<ReviewsView> {
           const SizedBox(width: 8),
           SizedBox(
             width: 20,
-            child: Text('$count',
-                style: const TextStyle(color: AppTheme.textMuted, fontSize: 11),
-                textAlign: TextAlign.end),
+            child: Text(
+              '$count',
+              style: const TextStyle(color: AppTheme.textMuted, fontSize: 11),
+              textAlign: TextAlign.end,
+            ),
           ),
         ],
       ),
@@ -400,20 +427,29 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.success.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: const Icon(Icons.check_circle_rounded,
-                  color: AppTheme.success, size: 20),
+              child: const Icon(
+                Icons.check_circle_rounded,
+                color: AppTheme.success,
+                size: 20,
+              ),
             ),
             const SizedBox(width: 12),
             const Expanded(
-              child: Text("You've reviewed this",
-                  style: TextStyle(fontWeight: FontWeight.w600)),
+              child: Text(
+                "You've reviewed this",
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
             ),
             TextButton(
-                onPressed: _showWriteReviewSheet, child: const Text('Edit')),
+              onPressed: _showWriteReviewSheet,
+              child: const Text('Edit'),
+            ),
             TextButton(
               onPressed: _deleteReview,
-              child:
-                  const Text('Delete', style: TextStyle(color: AppTheme.error)),
+              child: const Text(
+                'Delete',
+                style: TextStyle(color: AppTheme.error),
+              ),
             ),
           ],
         ),
@@ -428,11 +464,14 @@ class _ReviewsViewState extends State<ReviewsView> {
           children: [
             Icon(Icons.rate_review_rounded, color: Colors.white, size: 20),
             SizedBox(width: 8),
-            Text('Write a Review',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600)),
+            Text(
+              'Write a Review',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ],
         ),
       ),
@@ -454,33 +493,47 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.primaryColor.withValues(alpha: 0.1),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(Icons.rate_review_outlined,
-                  size: 40, color: AppTheme.primaryColor),
+              child: const Icon(
+                Icons.rate_review_outlined,
+                size: 40,
+                color: AppTheme.primaryColor,
+              ),
             ),
             const SizedBox(height: 20),
-            const Text('No reviews yet',
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const Text(
+              'No reviews yet',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
             const Text(
               'Be the first to share your experience!',
               style: TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 15, height: 1.5),
+                color: AppTheme.textSecondary,
+                fontSize: 15,
+                height: 1.5,
+              ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 28),
             if (!_checkingUserReview && _userReview == null)
               GlassButton(
                 onPressed: _showWriteReviewSheet,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 28, vertical: 14),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 28,
+                  vertical: 14,
+                ),
                 child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Icon(Icons.edit_rounded, color: Colors.white, size: 18),
                     SizedBox(width: 8),
-                    Text('Write a Review',
-                        style: TextStyle(
-                            color: Colors.white, fontWeight: FontWeight.w600)),
+                    Text(
+                      'Write a Review',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -504,12 +557,17 @@ class _ReviewsViewState extends State<ReviewsView> {
                 color: AppTheme.error.withValues(alpha: 0.1),
                 shape: BoxShape.circle,
               ),
-              child: const Icon(Icons.cloud_off_rounded,
-                  size: 36, color: AppTheme.error),
+              child: const Icon(
+                Icons.cloud_off_rounded,
+                size: 36,
+                color: AppTheme.error,
+              ),
             ),
             const SizedBox(height: 20),
-            const Text('Could not load reviews',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const Text(
+              'Could not load reviews',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 8),
             const Text(
               'Check your internet connection and try again.',
@@ -525,9 +583,13 @@ class _ReviewsViewState extends State<ReviewsView> {
                 children: [
                   Icon(Icons.refresh_rounded, color: Colors.white, size: 18),
                   SizedBox(width: 8),
-                  Text('Retry',
-                      style: TextStyle(
-                          color: Colors.white, fontWeight: FontWeight.w600)),
+                  Text(
+                    'Retry',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -564,7 +626,9 @@ class _ReviewsViewState extends State<ReviewsView> {
                             child: Text(
                               review.userName,
                               style: const TextStyle(
-                                  fontWeight: FontWeight.w600, fontSize: 14),
+                                fontWeight: FontWeight.w600,
+                                fontSize: 14,
+                              ),
                               overflow: TextOverflow.ellipsis,
                             ),
                           ),
@@ -572,25 +636,35 @@ class _ReviewsViewState extends State<ReviewsView> {
                             const SizedBox(width: 8),
                             Container(
                               padding: const EdgeInsets.symmetric(
-                                  horizontal: 6, vertical: 2),
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
                               decoration: BoxDecoration(
-                                color: AppTheme.primaryColor
-                                    .withValues(alpha: 0.15),
+                                color: AppTheme.primaryColor.withValues(
+                                  alpha: 0.15,
+                                ),
                                 borderRadius: BorderRadius.circular(6),
                               ),
-                              child: const Text('You',
-                                  style: TextStyle(
-                                      color: AppTheme.primaryColor,
-                                      fontSize: 11,
-                                      fontWeight: FontWeight.w600)),
+                              child: const Text(
+                                'You',
+                                style: TextStyle(
+                                  color: AppTheme.primaryColor,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                             ),
                           ],
                         ],
                       ),
                       const SizedBox(height: 2),
-                      Text(_formatDate(review.createdAt),
-                          style: const TextStyle(
-                              color: AppTheme.textMuted, fontSize: 12)),
+                      Text(
+                        _formatDate(review.createdAt),
+                        style: const TextStyle(
+                          color: AppTheme.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -602,7 +676,10 @@ class _ReviewsViewState extends State<ReviewsView> {
               Text(
                 review.comment,
                 style: const TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 14, height: 1.5),
+                  color: AppTheme.textSecondary,
+                  fontSize: 14,
+                  height: 1.5,
+                ),
               ),
             ],
             if (isOwn) ...[
@@ -617,9 +694,13 @@ class _ReviewsViewState extends State<ReviewsView> {
                     style: TextButton.styleFrom(
                       foregroundColor: AppTheme.primaryColor,
                       textStyle: const TextStyle(
-                          fontSize: 13, fontWeight: FontWeight.w500),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
                     ),
                   ),
                   TextButton.icon(
@@ -629,9 +710,13 @@ class _ReviewsViewState extends State<ReviewsView> {
                     style: TextButton.styleFrom(
                       foregroundColor: AppTheme.error,
                       textStyle: const TextStyle(
-                          fontSize: 13, fontWeight: FontWeight.w500),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 4),
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
                     ),
                   ),
                 ],
@@ -662,27 +747,35 @@ class _ReviewsViewState extends State<ReviewsView> {
       width: 42,
       height: 42,
       decoration: const BoxDecoration(
-          gradient: AppTheme.primaryGradient, shape: BoxShape.circle),
+        gradient: AppTheme.primaryGradient,
+        shape: BoxShape.circle,
+      ),
       child: review.userPhotoUrl != null
           ? ClipOval(
               child: CachedNetworkImage(
                 imageUrl: review.userPhotoUrl!,
                 fit: BoxFit.cover,
                 errorWidget: (_, __, ___) => Center(
-                  child: Text(initials.isEmpty ? 'U' : initials,
-                      style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 15)),
+                  child: Text(
+                    initials.isEmpty ? 'U' : initials,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 15,
+                    ),
+                  ),
                 ),
               ),
             )
           : Center(
-              child: Text(initials.isEmpty ? 'U' : initials,
-                  style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 15)),
+              child: Text(
+                initials.isEmpty ? 'U' : initials,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 15,
+                ),
+              ),
             ),
     );
   }
@@ -695,8 +788,8 @@ class _ReviewsViewState extends State<ReviewsView> {
           i < rating.floor()
               ? Icons.star_rounded
               : i < rating
-                  ? Icons.star_half_rounded
-                  : Icons.star_border_rounded,
+              ? Icons.star_half_rounded
+              : Icons.star_border_rounded,
           color: Colors.amber,
           size: size,
         );
@@ -742,8 +835,9 @@ class _WriteReviewSheet extends StatefulWidget {
 }
 
 class _WriteReviewSheetState extends State<_WriteReviewSheet> {
-  late final ReviewService _reviewService =
-      ReviewService(contentCollection: widget.contentCollection);
+  late final ReviewService _reviewService = ReviewService(
+    contentCollection: widget.contentCollection,
+  );
   final TextEditingController _commentController = TextEditingController();
   int _selectedRating = 0;
   bool _isSubmitting = false;
@@ -804,13 +898,16 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
         widget.onSubmitted(review);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(widget.existingReview == null
-                ? 'Review submitted!'
-                : 'Review updated!'),
+            content: Text(
+              widget.existingReview == null
+                  ? 'Review submitted!'
+                  : 'Review updated!',
+            ),
             backgroundColor: AppTheme.success,
             behavior: SnackBarBehavior.floating,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
           ),
         );
       }
@@ -824,8 +921,9 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
   Widget build(BuildContext context) {
     final isEditing = widget.existingReview != null;
     return Padding(
-      padding:
-          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
       child: Container(
         decoration: const BoxDecoration(
           color: AppTheme.surfaceColor,
@@ -852,13 +950,17 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                     Text(
                       isEditing ? 'Edit Your Review' : 'Rate this Content',
                       style: const TextStyle(
-                          fontSize: 22, fontWeight: FontWeight.bold),
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                     const SizedBox(height: 4),
                     const Text(
                       'Your feedback helps others make better decisions.',
                       style: TextStyle(
-                          color: AppTheme.textSecondary, fontSize: 14),
+                        color: AppTheme.textSecondary,
+                        fontSize: 14,
+                      ),
                     ),
                     const SizedBox(height: 32),
                     // Star picker
@@ -870,10 +972,12 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                             children: List.generate(5, (i) {
                               final filled = i < _selectedRating;
                               return Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 4),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 4,
+                                ),
                                 child: IconButton(
-                                  tooltip: 'Rate ${i + 1} star${i == 0 ? '' : 's'}',
+                                  tooltip:
+                                      'Rate ${i + 1} star${i == 0 ? '' : 's'}',
                                   iconSize: 48,
                                   padding: EdgeInsets.zero,
                                   constraints: const BoxConstraints(),
@@ -938,14 +1042,17 @@ class _WriteReviewSheetState extends State<_WriteReviewSheet> {
                                 height: 20,
                                 width: 20,
                                 child: CircularProgressIndicator(
-                                    strokeWidth: 2, color: Colors.white),
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
                               )
                             : Text(
                                 isEditing ? 'Update Review' : 'Submit Review',
                                 style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w600),
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
                               ),
                       ),
                     ),


### PR DESCRIPTION
💡 **What:** Added a `tooltip: 'Back'` property to the leading `IconButton` in the app bar of the `ReviewsView`.
🎯 **Why:** The icon-only "Back" button lacked a descriptive label, making its purpose unclear to screen reader users and missing helpful visual hover feedback for mouse users.
📸 **Before/After:** No visual layout change. Hovering over the back button or using a screen reader now reads "Back".
♿ **Accessibility:** Improves accessibility for visually impaired users relying on screen readers and adds clarity for mouse users.

---
*PR created automatically by Jules for task [13138086114315083356](https://jules.google.com/task/13138086114315083356) started by @manupawickramasinghe*