### PR TITLE
🎨 Palette: [Mobile Keyboard UX] Dismiss keyboard on search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,13 +10,16 @@
 ## 2026-03-25 - Interactive Components Tap Feedback
 **Learning:** When replacing `GestureDetector` with `Material` and `InkWell` for visual tap feedback inside `GlassCard` components, applying padding globally inside the `InkWell` can break edge-to-edge layouts (like cover images/thumbnails).
 **Action:** Always maintain the exact padding structure of the original component. Shift padding selectively to inner children only where needed, ensuring elements designed to be flush with the card's border retain their styling.
-\n## 2024-05-30 - Replace GestureDetector with Material+InkWell for Interactive Elements\n**Learning:** Using `GestureDetector` for interactive widgets like cards, chips, and navigation items fails to provide visual tap feedback and misses out on implicit accessibility semantics (like screen readers identifying the element as a button). \n**Action:** When wrapping a widget to make it interactive, prefer using `Material` combined with `InkWell` inside the container to automatically provide visual ripple effects and implicit semantic button traits.
+
+## 2024-05-30 - Replace GestureDetector with Material+InkWell for Interactive Elements
+**Learning:** Using `GestureDetector` for interactive widgets like cards, chips, and navigation items fails to provide visual tap feedback and misses out on implicit accessibility semantics (like screen readers identifying the element as a button).
+**Action:** When wrapping a widget to make it interactive, prefer using `Material` combined with `InkWell` inside the container to automatically provide visual ripple effects and implicit semantic button traits.
 ## 2026-03-29 - [Form Accessibility and Feedback]
 **Learning:** Found that when buttons submit forms using `GlassButton` or similar custom buttons, if they only change opacity to indicate an inactive/loading state, it may be insufficient for accessibility and clear user feedback, especially without an ARIA label or `Semantics` equivalent in Flutter.
 **Action:** Always ensure buttons used for async actions show a visible loading state (like `CircularProgressIndicator`) and have explicit `Semantics` or descriptive labels to indicate their current state (e.g., 'Loading, please wait') to screen readers.
 ## 2024-04-01 - Wrap visual data groups in Semantics
 **Learning:** In Flutter, when displaying data groups like a statistic (e.g., a number followed by a label like "12 Courses"), standard layout widgets (like `Column`) cause screen readers to read each element disjointedly, creating a poor experience.
-**Action:** Wrap grouped visual elements (like statistics or ratings) in a `Semantics` widget with `excludeSemantics: true` and provide a single cohesive `label` (e.g., `'$value $label'`) to prevent screen readers from reading individual elements disjointedly.
+**Action:** Wrap grouped visual elements (like statistics or ratings) in a `Semantics` widget with `excludeSemantics: true` and provide a single cohesive `label` (e.g., ` `) to prevent screen readers from reading individual elements disjointedly.
 
 ## 2024-05-31 - [Interactive Tabs and Dynamic Content]
 **Learning:** Found that custom tab-like navigation elements in Flutter are often built as static `Container`s within `StatelessWidget`s, meaning they lack visual feedback (ripple effect) when tapped, and the surrounding view doesn't update its content based on the active tab, resulting in a confusing UX.
@@ -27,3 +30,6 @@
 ## 2024-05-30 - Replace GestureDetector with IconButton for Icon grids
 **Learning:** In Flutter, wrapping interactive icons inside `GestureDetector` fails to provide visual tap feedback (ripple effects) and lacks explicit accessible properties for screen readers, breaking standard UX expectations.
 **Action:** Always prefer `IconButton` to make individual icons interactive. Configure it with a descriptive `tooltip` for immediate screen reader labeling and visual tooltips on hover. Adjust `padding` to `EdgeInsets.zero` and use `constraints: const BoxConstraints()` if you need to match tight previous layout boundaries without losing semantic traits.
+## 2024-06-25 - [Search Bar Keyboard Interaction]
+**Learning:** For in-app search experiences on mobile, standard `TextField`s do not auto-dismiss the keyboard when the user presses enter/search on the virtual keyboard. This creates a poor user experience where results are hidden.
+**Action:** Always configure search `TextField`s with `textInputAction: TextInputAction.search` to trigger the correct keyboard icon, and provide an `onSubmitted` callback that dismisses the keyboard explicitly using `FocusScope.of(context).unfocus()`.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -89,14 +89,16 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       _filteredVideos = _allVideos.where((v) {
-        final matchesSearch = isQueryEmpty ||
+        final matchesSearch =
+            isQueryEmpty ||
             searchRegex!.hasMatch(v.title) ||
             searchRegex.hasMatch(v.description);
         return matchesSearch;
       }).toList();
 
       _filteredCourses = _allCourses.where((c) {
-        final matchesSearch = isQueryEmpty ||
+        final matchesSearch =
+            isQueryEmpty ||
             searchRegex!.hasMatch(c.title) ||
             searchRegex.hasMatch(c.description);
         final matchesCategory =
@@ -144,6 +146,8 @@ class _ExploreViewState extends State<ExploreView> {
                       builder: (context, value, child) {
                         return TextField(
                           controller: _searchController,
+                          textInputAction: TextInputAction.search,
+                          onSubmitted: (_) => FocusScope.of(context).unfocus(),
                           style: const TextStyle(color: Colors.white),
                           decoration: InputDecoration(
                             hintText: 'Search courses and videos...',

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,12 @@
-💡 What: Converted the eagerly built `ListView` in `ReviewsView` (which iterated over reviews with a `for` loop inside `children`) to use `ListView.builder`.
-🎯 Why: Eagerly building all list items at once destroys virtualization. For potentially unbounded datasets (like a list of reviews), this blocks the UI thread during the initial render and leads to unscalable memory consumption.
-📊 Impact: Significant reduction in memory usage and elimination of initial UI thread blocking when rendering large lists of reviews, maintaining smooth 60fps scrolling.
-🔬 Measurement: Verify that memory consumption remains stable regardless of the number of loaded reviews (using Flutter DevTools), and observe that the initial render time of `ReviewsView` is no longer proportional to the total number of reviews.
+💡 What
+Added `textInputAction: TextInputAction.search` and an `onSubmitted` handler to the search `TextField` in `ExploreView`.
+
+🎯 Why
+By default, standard `TextField` widgets do not automatically dismiss the virtual keyboard upon submission. When a user searched for courses or videos, the keyboard remained open, obscuring the results and requiring a manual swipe to dismiss. This change ensures the correct "Search" key is shown on the keyboard and automatically dismisses it upon submission.
+
+📸 Before/After
+*   **Before:** Pressing Enter/Return on the keyboard triggered the search logic, but the keyboard remained on screen.
+*   **After:** The keyboard displays a Search icon on the action button, and tapping it immediately executes the search and collapses the keyboard, revealing the content.
+
+♿ Accessibility
+Improves keyboard interaction logic and ensures standard mobile OS behavior is respected.


### PR DESCRIPTION
💡 What
Added `textInputAction: TextInputAction.search` and an `onSubmitted` handler to the search `TextField` in `ExploreView`.

🎯 Why
By default, standard `TextField` widgets do not automatically dismiss the virtual keyboard upon submission. When a user searched for courses or videos, the keyboard remained open, obscuring the results and requiring a manual swipe to dismiss. This change ensures the correct "Search" key is shown on the keyboard and automatically dismisses it upon submission.

📸 Before/After
*   **Before:** Pressing Enter/Return on the keyboard triggered the search logic, but the keyboard remained on screen.
*   **After:** The keyboard displays a Search icon on the action button, and tapping it immediately executes the search and collapses the keyboard, revealing the content.

♿ Accessibility
Improves keyboard interaction logic and ensures standard mobile OS behavior is respected.

---
*PR created automatically by Jules for task [7318049664684632051](https://jules.google.com/task/7318049664684632051) started by @manupawickramasinghe*