### PR TITLE
🎨 Palette: [UX improvement] Add Semantics to Star Ratings

### DIFF
--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -509,17 +509,21 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                     ),
                   ),
                 ),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: List.generate(5, (i) {
-                    return Icon(
-                      i < review.rating
-                          ? Icons.star_rounded
-                          : Icons.star_border_rounded,
-                      color: Colors.amber,
-                      size: 14,
-                    );
-                  }),
+                Semantics(
+                  label: 'Rating: ${review.rating.toStringAsFixed(1)} stars',
+                  excludeSemantics: true,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: List.generate(5, (i) {
+                      return Icon(
+                        i < review.rating
+                            ? Icons.star_rounded
+                            : Icons.star_border_rounded,
+                        color: Colors.amber,
+                        size: 14,
+                      );
+                    }),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
💡 What: Wrapped the visual star rating `Row` in `lib/views/video/video_player_view.dart` with a `Semantics` widget.
🎯 Why: To improve screen reader accessibility. Previously, screen readers would disjointedly read out 'star, star, star...'.
📸 Before/After: N/A (Visuals are identical, purely semantic change).
♿ Accessibility: Assistive technologies will now announce a cohesive label like 'Rating: 4.5 stars' instead of individual icons.

---
*PR created automatically by Jules for task [8421485456745249006](https://jules.google.com/task/8421485456745249006) started by @manupawickramasinghe*