### PR TITLE
🔒 Fix hardcoded HTTP API Base URL

### DIFF
--- a/lib/studies/lms/data_service.dart
+++ b/lib/studies/lms/data_service.dart
@@ -25,12 +25,19 @@ class Video {
 }
 
 class LmsDataService {
-  final String baseUrl = 'http://localhost:5000';
+  static const String baseUrl = String.fromEnvironment(
+    'LMS_API_BASE_URL',
+    defaultValue: 'https://api.hackston-lms.com',
+  );
+
+  final http.Client _client;
   static String? _authToken;
+
+  LmsDataService({http.Client? client}) : _client = client ?? http.Client();
 
   /// Authenticates the user and retrieves a JWT token.
   Future<void> login(String email, String password) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('$baseUrl/api/auth/login'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'email': email, 'password': password}),
@@ -50,7 +57,7 @@ class LmsDataService {
       throw Exception('Not authenticated. Please login first.');
     }
 
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('$baseUrl/api/videos'),
       headers: {
         'Content-Type': 'application/json',

--- a/lib/studies/lms/video_player_screen.dart
+++ b/lib/studies/lms/video_player_screen.dart
@@ -22,7 +22,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen> {
     super.initState();
     // The videoUrl from the backend is relative (e.g., "uploads/video-....mp4")
     // We need to prepend the base URL to make it a full, playable URL.
-    final fullVideoUrl = LmsDataService().baseUrl + '/' + widget.video.videoUrl;
+    final fullVideoUrl = LmsDataService.baseUrl + '/' + widget.video.videoUrl;
 
     _videoPlayerController = VideoPlayerController.networkUrl(
       Uri.parse(fullVideoUrl),

--- a/test/studies/lms/data_service_test.dart
+++ b/test/studies/lms/data_service_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:hackston_lms/studies/lms/data_service.dart';
+
+class MockClient extends http.BaseClient {
+  http.Response? response;
+  Uri? lastUrl;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    lastUrl = request.url;
+    final res = response ?? http.Response('', 200);
+    return http.StreamedResponse(
+      Stream.value(res.bodyBytes),
+      res.statusCode,
+      headers: res.headers,
+    );
+  }
+}
+
+void main() {
+  group('LmsDataService Tests', () {
+    test('baseUrl defaults to https://api.hackston-lms.com', () {
+      expect(LmsDataService.baseUrl, 'https://api.hackston-lms.com');
+    });
+
+    test('login sends request to the correct URL', () async {
+      final mockClient = MockClient();
+      mockClient.response = http.Response(
+        jsonEncode({'token': 'fake_token'}),
+        200,
+      );
+      final dataService = LmsDataService(client: mockClient);
+
+      await dataService.login('test@example.com', 'password');
+
+      expect(
+        mockClient.lastUrl.toString(),
+        '${LmsDataService.baseUrl}/api/auth/login',
+      );
+    });
+
+    test('fetchVideos sends request to the correct URL', () async {
+      final mockClient = MockClient();
+      // First login to set token
+      mockClient.response = http.Response(
+        jsonEncode({'token': 'fake_token'}),
+        200,
+      );
+      final dataService = LmsDataService(client: mockClient);
+      await dataService.login('test@example.com', 'password');
+
+      mockClient.response = http.Response(jsonEncode([]), 200);
+      await dataService.fetchVideos();
+
+      expect(
+        mockClient.lastUrl.toString(),
+        '${LmsDataService.baseUrl}/api/videos',
+      );
+    });
+  });
+}


### PR DESCRIPTION
🎯 What: Fixed the hardcoded HTTP base URL in LmsDataService.
⚠️ Risk: Hardcoded HTTP URLs are vulnerable to Man-in-the-Middle (MitM) attacks and make environment-specific configuration difficult.
🛡️ Solution: Switched the default base URL to HTTPS and refactored the service to use String.fromEnvironment for build-time configuration. Also introduced dependency injection for http.Client to improve testability.

## Description

*Please describe the motivation behind this change.*

## Tests

*Please describe the tests that you added or updated to verify your changes.*

## Issues
Fixes #

---

>**Note**: Please find the development and releasing instructions at https://github.com/flutter/gallery#development
