### PR TITLE
⚡ Bolt: Optimize StreamBuilder by caching streams

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -53,3 +53,6 @@
 ## 2024-05-15 - [Avoid flawed cache-first Firestore patterns]
 **Learning:** [A manual cache-first fetching approach (fetching from cache, then fallback) permanently serves stale data once cache is populated.]
 **Action:** [Rely on Firestore's native Source.serverAndCache default behavior instead.]
+## 2026-04-09 - Optimize StreamBuilder by caching streams
+ **Learning:** Creating streams inside the 'build' method or its helpers causes StreamBuilder to re-subscribe on every rebuild, leading to redundant Firestore listener allocations and UI flickering.
+ **Action:** Always initialize and store streams in 'initState' (and update in 'didUpdateWidget' if needed) when using StreamBuilder in a StatefulWidget.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -20,6 +20,21 @@ class CourseDetailView extends StatefulWidget {
 class _CourseDetailViewState extends State<CourseDetailView> {
   final ReviewService _reviewService =
       ReviewService(contentCollection: 'courses');
+  late Stream<List<Review>> _reviewsStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _reviewsStream = _reviewService.getReviews(widget.course.id);
+  }
+
+  @override
+  void didUpdateWidget(covariant CourseDetailView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.course.id != widget.course.id) {
+      _reviewsStream = _reviewService.getReviews(widget.course.id);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -261,7 +276,7 @@ class _CourseDetailViewState extends State<CourseDetailView> {
           ),
           const SizedBox(height: 14),
           StreamBuilder<List<Review>>(
-            stream: _reviewService.getReviews(widget.course.id),
+            stream: _reviewsStream,
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -33,11 +33,21 @@ class _ReviewsViewState extends State<ReviewsView> {
   Review? _userReview;
   bool _checkingUserReview = true;
   _SortBy _sortBy = _SortBy.newest;
+  late Stream<List<Review>> _reviewsStream;
 
   @override
   void initState() {
     super.initState();
+    _reviewsStream = _reviewService.getReviews(widget.contentId);
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkUserReview());
+  }
+
+  @override
+  void didUpdateWidget(covariant ReviewsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.contentId != widget.contentId) {
+      _reviewsStream = _reviewService.getReviews(widget.contentId);
+    }
   }
 
   Future<void> _checkUserReview() async {
@@ -177,7 +187,7 @@ class _ReviewsViewState extends State<ReviewsView> {
       ),
       body: GradientBackground(
         child: StreamBuilder<List<Review>>(
-          stream: _reviewService.getReviews(widget.contentId),
+          stream: _reviewsStream,
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -23,11 +23,21 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   bool _hasError = false;
   final ReviewService _reviewService =
       ReviewService(contentCollection: 'videos');
+  late Stream<List<Review>> _reviewsStream;
 
   @override
   void initState() {
     super.initState();
+    _reviewsStream = _reviewService.getReviews(widget.video.id);
     _initializePlayer();
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoPlayerView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.video.id != widget.video.id) {
+      _reviewsStream = _reviewService.getReviews(widget.video.id);
+    }
   }
 
   Future<void> _initializePlayer() async {
@@ -254,7 +264,7 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
         ),
         const SizedBox(height: 14),
         StreamBuilder<List<Review>>(
-          stream: _reviewService.getReviews(widget.video.id),
+          stream: _reviewsStream,
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(


### PR DESCRIPTION
- Refactored `CourseDetailView`, `ReviewsView`, and `VideoPlayerView` to initialize and cache streams in `initState`.
- Implemented `didUpdateWidget` to re-initialize streams when source IDs change.
- Updated `StreamBuilder`s to use cached stream instances.
- Documented the optimization in `.jules/bolt.md`.

## Description

*Please describe the motivation behind this change.*

## Tests

*Please describe the tests that you added or updated to verify your changes.*

## Issues
Fixes #

---

>**Note**: Please find the development and releasing instructions at https://github.com/flutter/gallery#development
