### PR TITLE
🎨 Palette: [Add semantics to custom search bar]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,6 @@
 ## 2026-04-19 - Cohesive Semantics for Star Ratings
 **Learning:** When displaying grouped visual indicators like star ratings (e.g., using a `Row` of `Icon` widgets), screen readers will announce each icon individually (e.g., 'star, star, star, star, star'), creating a tedious and disjointed user experience.
 **Action:** Wrap the visually grouped data in a `Semantics` widget with `excludeSemantics: true` and provide a single cohesive `label` (e.g., 'Rating: 4.5 stars') to ensure a clear, concise announcement for assistive technology users.
+## 2024-05-24 - Accessibility for Custom Search Bar
+**Learning:** In Flutter, building custom interactive widgets using `InkWell` that look like inputs (like a pseudo-search bar) can be inaccessible to screen readers because they aren't announced as buttons or text fields natively.
+**Action:** Always wrap custom `InkWell`-based controls in a `Semantics` widget with explicit roles (e.g., `button: true`) and descriptive labels.

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -193,20 +193,25 @@ class _HomeViewState extends State<HomeView> {
       padding: EdgeInsets.zero,
       child: Material(
         color: Colors.transparent,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(16),
-          onTap: widget.onSearchTap,
-          child: const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-            child: Row(
-              children: [
-                Icon(Icons.search_rounded, color: AppTheme.textMuted, size: 22),
-                SizedBox(width: 12),
-                Text(
-                  'Search courses, videos...',
-                  style: TextStyle(color: AppTheme.textMuted, fontSize: 15),
-                ),
-              ],
+        child: Semantics(
+          button: true,
+          label: 'Search courses, videos...',
+          excludeSemantics: true,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(16),
+            onTap: widget.onSearchTap,
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+              child: Row(
+                children: [
+                  Icon(Icons.search_rounded, color: AppTheme.textMuted, size: 22),
+                  SizedBox(width: 12),
+                  Text(
+                    'Search courses, videos...',
+                    style: TextStyle(color: AppTheme.textMuted, fontSize: 15),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,4 @@
-💡 What: Replaced iterable methods (`.take()`, `.indexed`) with explicit, bounds-checked `for` loops inside widget `build` methods across the app (`course_detail_view.dart`, `video_player_view.dart`, `home_view.dart`, `profile_view.dart`).
-
-🎯 Why: In Flutter, chained iterable methods allocate intermediate objects (`TakeIterable`, `IndexedIterable`) and closures on every rebuild. When placed in frequently rebuilt `build` methods, this causes unnecessary garbage collection pressure and can lead to UI stuttering.
-
-📊 Impact: Reduces intermediate object allocation during UI rebuilds, specifically preventing O(N) allocation of iterable instances during list generation, decreasing GC pressure.
-
-🔬 Measurement: `flutter analyze` runs clean and `flutter test` passes successfully, verifying that all logic remains exactly identical.
+💡 What: Wrapped the custom search bar (`InkWell`) in `HomeView` with a `Semantics` widget.
+🎯 Why: To ensure screen readers announce the pseudo-search bar correctly as an interactive button.
+📸 Before/After: Visuals remain unchanged, but the accessibility tree now properly exposes the button.
+♿ Accessibility: Added `Semantics(button: true, label: 'Search courses, videos...', excludeSemantics: true)`.


### PR DESCRIPTION
💡 What: Wrapped the custom search bar (`InkWell`) in `HomeView` with a `Semantics` widget.
🎯 Why: To ensure screen readers announce the pseudo-search bar correctly as an interactive button.
📸 Before/After: Visuals remain unchanged, but the accessibility tree now properly exposes the button.
♿ Accessibility: Added `Semantics(button: true, label: 'Search courses, videos...', excludeSemantics: true)`.

---
*PR created automatically by Jules for task [14671623102054958706](https://jules.google.com/task/14671623102054958706) started by @manupawickramasinghe*