### PR TITLE
🎨 Palette: Make ripple effects visible on interactive cards

### DIFF
--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -89,16 +89,14 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       _filteredVideos = _allVideos.where((v) {
-        final matchesSearch =
-            isQueryEmpty ||
+        final matchesSearch = isQueryEmpty ||
             searchRegex!.hasMatch(v.title) ||
             searchRegex!.hasMatch(v.description);
         return matchesSearch;
       }).toList();
 
       _filteredCourses = _allCourses.where((c) {
-        final matchesSearch =
-            isQueryEmpty ||
+        final matchesSearch = isQueryEmpty ||
             searchRegex!.hasMatch(c.title) ||
             searchRegex!.hasMatch(c.description);
         final matchesCategory =
@@ -187,9 +185,8 @@ class _ExploreViewState extends State<ExploreView> {
                           child: AnimatedContainer(
                             duration: const Duration(milliseconds: 200),
                             decoration: BoxDecoration(
-                              gradient: isSelected
-                                  ? AppTheme.primaryGradient
-                                  : null,
+                              gradient:
+                                  isSelected ? AppTheme.primaryGradient : null,
                               color: isSelected
                                   ? null
                                   : Colors.white.withValues(alpha: 0.08),
@@ -318,17 +315,10 @@ class _ExploreViewState extends State<ExploreView> {
       padding: const EdgeInsets.only(bottom: 12, left: 20, right: 20),
       child: GlassCard(
         borderRadius: 16,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(16),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => CourseDetailView(course: course),
-              ),
-            ),
-            child: Padding(
+        padding: EdgeInsets.zero,
+        child: Stack(
+          children: [
+            Padding(
               padding: const EdgeInsets.all(14),
               child: Row(
                 children: [
@@ -419,7 +409,21 @@ class _ExploreViewState extends State<ExploreView> {
                 ],
               ),
             ),
-          ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => CourseDetailView(course: course),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -430,15 +434,10 @@ class _ExploreViewState extends State<ExploreView> {
       padding: const EdgeInsets.only(bottom: 12, left: 20, right: 20),
       child: GlassCard(
         borderRadius: 16,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(16),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => VideoPlayerView(video: video)),
-            ),
-            child: Padding(
+        padding: EdgeInsets.zero,
+        child: Stack(
+          children: [
+            Padding(
               padding: const EdgeInsets.all(14),
               child: Row(
                 children: [
@@ -489,7 +488,20 @@ class _ExploreViewState extends State<ExploreView> {
                 ],
               ),
             ),
-          ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video)),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -204,7 +204,11 @@ class _HomeViewState extends State<HomeView> {
               padding: EdgeInsets.symmetric(horizontal: 20, vertical: 16),
               child: Row(
                 children: [
-                  Icon(Icons.search_rounded, color: AppTheme.textMuted, size: 22),
+                  Icon(
+                    Icons.search_rounded,
+                    color: AppTheme.textMuted,
+                    size: 22,
+                  ),
                   SizedBox(width: 12),
                   Text(
                     'Search courses, videos...',
@@ -329,17 +333,11 @@ class _HomeViewState extends State<HomeView> {
       margin: const EdgeInsets.only(right: 16),
       child: GlassCard(
         borderRadius: 20,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(20),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => CourseDetailView(course: course),
-              ),
-            ),
-            child: Column(
+        padding: EdgeInsets.zero,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
@@ -445,7 +443,21 @@ class _HomeViewState extends State<HomeView> {
                 ),
               ],
             ),
-          ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(20),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => CourseDetailView(course: course),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -469,15 +481,10 @@ class _HomeViewState extends State<HomeView> {
       padding: const EdgeInsets.only(bottom: 12),
       child: GlassCard(
         borderRadius: 16,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(16),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => VideoPlayerView(video: video)),
-            ),
-            child: Padding(
+        padding: EdgeInsets.zero,
+        child: Stack(
+          children: [
+            Padding(
               padding: const EdgeInsets.all(14),
               child: Row(
                 children: [
@@ -538,7 +545,21 @@ class _HomeViewState extends State<HomeView> {
                 ],
               ),
             ),
-          ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => VideoPlayerView(video: video),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## 💡 What
Restructured `CourseCard` and `VideoCard` components in `home_view.dart` and `explore_view.dart` to use a `Stack` layout. The interactive `InkWell` is now placed on top of the card's visual contents using `Positioned.fill`.

## 🎯 Why
Previously, the `InkWell` wrapped the card's contents directly. Because the cards contain opaque elements (like gradient backgrounds and `CachedNetworkImage`s), the ripple/splash effect from taps was painted underneath these elements, making the tactile feedback invisible to the user. This update ensures users get clear visual confirmation when they tap a card.

## 📸 Before/After
- **Before:** Tapping a card produced no visible ripple effect because it was hidden behind the image/gradient.
- **After:** Tapping a card now displays a subtle, standard Material ripple effect over the entire card area.

## ♿ Accessibility
Improved visual feedback directly aids users by confirming that their touch interaction was registered by the system.

---
*PR created automatically by Jules for task [16800483614317041780](https://jules.google.com/task/16800483614317041780) started by @manupawickramasinghe*