### PR TITLE
🎨 Palette: Add semantics for category selection chips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -38,3 +38,6 @@
 ## 2024-05-24 - Accessibility for Custom Search Bar
 **Learning:** In Flutter, building custom interactive widgets using `InkWell` that look like inputs (like a pseudo-search bar) can be inaccessible to screen readers because they aren't announced as buttons or text fields natively.
 **Action:** Always wrap custom `InkWell`-based controls in a `Semantics` widget with explicit roles (e.g., `button: true`) and descriptive labels.
+## 2024-04-30 - Flutter Semantic Wrapping for Interactive InkWells
+**Learning:** In Flutter, using `InkWell` directly inside a `Material` widget creates visually appealing interactive tabs or chips, but it does not automatically expose its role or state to accessibility services. We found a recurring pattern in the app where custom interactive elements (like the category selector in `ExploreView`) missed crucial a11y context.
+**Action:** When implementing custom interactive widgets that act as tabs or toggle buttons using `InkWell` or `GestureDetector`, always wrap them in a `Semantics` widget. Explicitly define `button: true` and pass its current state via `selected: isSelected` so screen readers correctly identify it as an interactive, selectable control and announce its active status.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -201,27 +201,32 @@ class _ExploreViewState extends State<ExploreView> {
                             ),
                             child: Material(
                               color: Colors.transparent,
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(20),
-                                onTap: () {
-                                  setState(() => _selectedCategory = category);
-                                  _filterContent();
-                                },
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 18,
-                                    vertical: 8,
-                                  ),
-                                  child: Text(
-                                    category,
-                                    style: TextStyle(
-                                      color: isSelected
-                                          ? Colors.white
-                                          : AppTheme.textSecondary,
-                                      fontWeight: isSelected
-                                          ? FontWeight.w600
-                                          : FontWeight.w500,
-                                      fontSize: 14,
+                              child: Semantics(
+                                button: true,
+                                selected: isSelected,
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(20),
+                                  onTap: () {
+                                    setState(
+                                        () => _selectedCategory = category);
+                                    _filterContent();
+                                  },
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 18,
+                                      vertical: 8,
+                                    ),
+                                    child: Text(
+                                      category,
+                                      style: TextStyle(
+                                        color: isSelected
+                                            ? Colors.white
+                                            : AppTheme.textSecondary,
+                                        fontWeight: isSelected
+                                            ? FontWeight.w600
+                                            : FontWeight.w500,
+                                        fontSize: 14,
+                                      ),
                                     ),
                                   ),
                                 ),


### PR DESCRIPTION
💡 **What**: Wrapped the category selection chips (`InkWell`) in `ExploreView` with a `Semantics` widget.
🎯 **Why**: Previously, the category chips were visually interactive but lacked accessibility properties. Screen readers did not identify them as interactive controls or announce which category was currently selected.
📸 **Before/After**: N/A - The visual appearance remains unchanged, only the accessibility layer is updated.
♿ **Accessibility**: Added `button: true` and `selected: isSelected` properties to the `Semantics` widget. This ensures screen readers correctly interpret the chips as selectable buttons and announce the active category state to users relying on assistive technologies.

---
*PR created automatically by Jules for task [17768168651322371757](https://jules.google.com/task/17768168651322371757) started by @manupawickramasinghe*