### PR TITLE
🎨 Palette: Add autofill hints and disable autocorrect on auth fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,7 @@
 ## 2024-04-30 - Flutter Semantic Wrapping for Interactive InkWells
 **Learning:** In Flutter, using `InkWell` directly inside a `Material` widget creates visually appealing interactive tabs or chips, but it does not automatically expose its role or state to accessibility services. We found a recurring pattern in the app where custom interactive elements (like the category selector in `ExploreView`) missed crucial a11y context.
 **Action:** When implementing custom interactive widgets that act as tabs or toggle buttons using `InkWell` or `GestureDetector`, always wrap them in a `Semantics` widget. Explicitly define `button: true` and pass its current state via `selected: isSelected` so screen readers correctly identify it as an interactive, selectable control and announce its active status.
+
+## 2024-05-02 - Autofill and Autocorrect for Credential Fields
+**Learning:** TextFields intended for credentials (e.g., email addresses, passwords, names) should actively guide the user and avoid confusing autocorrect modifications. Missing `autofillHints` makes users rely on external password managers manually or type repetitively, while left-on `autocorrect` can erroneously rewrite parts of emails.
+**Action:** Always add appropriate `autofillHints` (e.g., `AutofillHints.email`, `AutofillHints.password`, `AutofillHints.newPassword`) to credential inputs. Explicitly set `autocorrect: false` on inputs like emails where the user's explicit input must be preserved without autocorrect interference.

--- a/lib/views/auth/forgot_password_view.dart
+++ b/lib/views/auth/forgot_password_view.dart
@@ -162,6 +162,8 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView>
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           textInputAction: TextInputAction.done,
+          autocorrect: false,
+          autofillHints: const [AutofillHints.email],
           style: const TextStyle(color: Colors.white),
           onSubmitted: (_) {
             if (!auth.isLoading) _handleReset(auth);

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -31,10 +31,10 @@ class _LoginViewState extends State<LoginView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim =
-        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
-      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-    );
+    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
+        .animate(
+          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+        );
     _animController.forward();
   }
 
@@ -134,6 +134,8 @@ class _LoginViewState extends State<LoginView>
                                   controller: _emailController,
                                   keyboardType: TextInputType.emailAddress,
                                   textInputAction: TextInputAction.next,
+                                  autocorrect: false,
+                                  autofillHints: const [AutofillHints.email],
                                   style: const TextStyle(color: Colors.white),
                                   decoration: const InputDecoration(
                                     labelText: 'Email Address',
@@ -145,6 +147,7 @@ class _LoginViewState extends State<LoginView>
                                   controller: _passwordController,
                                   obscureText: !_isPasswordVisible,
                                   textInputAction: TextInputAction.done,
+                                  autofillHints: const [AutofillHints.password],
                                   style: const TextStyle(color: Colors.white),
                                   onSubmitted: (_) {
                                     if (!auth.isLoading) _handleLogin(auth);

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -30,10 +30,10 @@ class _SignupViewState extends State<SignupView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim =
-        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
-      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-    );
+    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
+        .animate(
+          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+        );
     _animController.forward();
   }
 
@@ -116,7 +116,8 @@ class _SignupViewState extends State<SignupView>
                         children: [
                           const SizedBox(height: 10),
                           const Center(
-                              child: AppLogo(size: 56, showText: false)),
+                            child: AppLogo(size: 56, showText: false),
+                          ),
                           const SizedBox(height: 32),
                           GlassCard(
                             padding: const EdgeInsets.all(28),
@@ -144,6 +145,7 @@ class _SignupViewState extends State<SignupView>
                                   controller: _nameController,
                                   textInputAction: TextInputAction.next,
                                   textCapitalization: TextCapitalization.words,
+                                  autofillHints: const [AutofillHints.name],
                                   style: const TextStyle(color: Colors.white),
                                   decoration: const InputDecoration(
                                     labelText: 'Full Name',
@@ -155,6 +157,8 @@ class _SignupViewState extends State<SignupView>
                                   controller: _emailController,
                                   keyboardType: TextInputType.emailAddress,
                                   textInputAction: TextInputAction.next,
+                                  autocorrect: false,
+                                  autofillHints: const [AutofillHints.email],
                                   style: const TextStyle(color: Colors.white),
                                   decoration: const InputDecoration(
                                     labelText: 'Email Address',
@@ -166,6 +170,9 @@ class _SignupViewState extends State<SignupView>
                                   controller: _passwordController,
                                   obscureText: !_isPasswordVisible,
                                   textInputAction: TextInputAction.done,
+                                  autofillHints: const [
+                                    AutofillHints.newPassword,
+                                  ],
                                   style: const TextStyle(color: Colors.white),
                                   onSubmitted: (_) {
                                     if (!auth.isLoading) _handleSignup(auth);

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,4 @@
+💡 What: Added appropriate `autofillHints` and `autocorrect: false` to credential text fields across the auth views (Login, Signup, Forgot Password).
+🎯 Why: TextFields intended for credentials should actively guide the user and avoid confusing autocorrect modifications. Adding `autofillHints` allows password managers to work seamlessly, and disabling `autocorrect` ensures email addresses are not erroneously rewritten.
+📸 Before/After: Before, fields lacked autofill support and could autocorrect email addresses. Now, they correctly integrate with OS autofill and preserve typed text exactly.
+♿ Accessibility: Improves usability by reducing repetitive typing and integrating with systemic password management tools, which is particularly helpful for users with motor or cognitive impairments.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,10 +492,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -777,10 +777,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:
@@ -910,5 +910,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"


### PR DESCRIPTION
💡 What: Added appropriate `autofillHints` and `autocorrect: false` to credential text fields across the auth views (Login, Signup, Forgot Password).
🎯 Why: TextFields intended for credentials should actively guide the user and avoid confusing autocorrect modifications. Adding `autofillHints` allows password managers to work seamlessly, and disabling `autocorrect` ensures email addresses are not erroneously rewritten.
📸 Before/After: Before, fields lacked autofill support and could autocorrect email addresses. Now, they correctly integrate with OS autofill and preserve typed text exactly.
♿ Accessibility: Improves usability by reducing repetitive typing and integrating with systemic password management tools, which is particularly helpful for users with motor or cognitive impairments.

---
*PR created automatically by Jules for task [5099340637821585442](https://jules.google.com/task/5099340637821585442) started by @manupawickramasinghe*