### PR TITLE
🎨 Palette: Add semantic roles and states to navigation items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2024-05-02 - Autofill and Autocorrect for Credential Fields
 **Learning:** TextFields intended for credentials (e.g., email addresses, passwords, names) should actively guide the user and avoid confusing autocorrect modifications. Missing `autofillHints` makes users rely on external password managers manually or type repetitively, while left-on `autocorrect` can erroneously rewrite parts of emails.
 **Action:** Always add appropriate `autofillHints` (e.g., `AutofillHints.email`, `AutofillHints.password`, `AutofillHints.newPassword`) to credential inputs. Explicitly set `autocorrect: false` on inputs like emails where the user's explicit input must be preserved without autocorrect interference.
+
+## 2024-05-03 - Add semantic roles and states to custom navigation items
+**Learning:** Custom bottom navigation items built with `InkWell` in Flutter are only read as text by screen readers unless explicitly wrapped in a `Semantics` widget. Screen readers need `button: true` to know they are interactive tabs, and `selected: isSelected` to communicate their current selection state to the user.
+**Action:** Always wrap `InkWell` or `GestureDetector` based custom navigation elements in `Semantics(button: true, selected: ...)` to ensure correct accessibility roles and states are announced.

--- a/lib/core/glass_widgets.dart
+++ b/lib/core/glass_widgets.dart
@@ -327,31 +327,35 @@ class _NavItem extends StatelessWidget {
       ),
       child: Material(
         color: Colors.transparent,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(12),
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  icon,
-                  color:
-                      isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
-                  size: 24,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  label,
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+        child: Semantics(
+          button: true,
+          selected: isSelected,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    icon,
                     color:
                         isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
+                    size: 24,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 4),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                      color:
+                          isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
💡 **What:** Wrapped the interactive custom navigation tab items (`_NavItem`) in `lib/core/glass_widgets.dart` with a `Semantics` widget.
🎯 **Why:** To expose the elements to assistive technologies as interactive buttons and clearly indicate which tab is currently selected.
📸 **Before/After:** Not applicable (visuals remain identical).
♿ **Accessibility:** Screen readers will now correctly identify the tabs as buttons and announce their selection state (e.g., "Home, button, selected" instead of just "Home").

---
*PR created automatically by Jules for task [6683584081681071102](https://jules.google.com/task/6683584081681071102) started by @manupawickramasinghe*