### PR TITLE
🎨 Palette: Add Semantics to My Learning tabs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,6 @@
 ## 2024-05-03 - Add semantic roles and states to custom navigation items
 **Learning:** Custom bottom navigation items built with `InkWell` in Flutter are only read as text by screen readers unless explicitly wrapped in a `Semantics` widget. Screen readers need `button: true` to know they are interactive tabs, and `selected: isSelected` to communicate their current selection state to the user.
 **Action:** Always wrap `InkWell` or `GestureDetector` based custom navigation elements in `Semantics(button: true, selected: ...)` to ensure correct accessibility roles and states are announced.
+## 2026-05-04 - Wrap Custom Tab Buttons in Semantics
+**Learning:** In Flutter, when building custom tab controls or bottom navigation items using `InkWell` inside a container (like the tabs in My Learning), screen readers won't automatically know they are interactive buttons or which one is active.
+**Action:** Always wrap the `InkWell` of custom tab buttons in a `Semantics` widget. Set `button: true` to announce it's clickable and `selected: isSelected` to announce its active state.

--- a/lib/views/my_learning/my_learning_view.dart
+++ b/lib/views/my_learning/my_learning_view.dart
@@ -69,22 +69,26 @@ class _MyLearningViewState extends State<MyLearningView> {
         ),
         child: Material(
           color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(10),
-            onTap: () {
-              setState(() {
-                _selectedTabIndex = index;
-              });
-            },
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12),
-              child: Text(
-                label,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: isActive ? Colors.white : AppTheme.textSecondary,
-                  fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
-                  fontSize: 14,
+          child: Semantics(
+            button: true,
+            selected: isActive,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(10),
+              onTap: () {
+                setState(() {
+                  _selectedTabIndex = index;
+                });
+              },
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: isActive ? Colors.white : AppTheme.textSecondary,
+                    fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                    fontSize: 14,
+                  ),
                 ),
               ),
             ),
@@ -108,7 +112,8 @@ class _MyLearningViewState extends State<MyLearningView> {
       case 2:
         icon = Icons.bookmark_rounded;
         title = 'No Saved Courses';
-        subtitle = 'Save courses you are interested in\nto find them quickly later.';
+        subtitle =
+            'Save courses you are interested in\nto find them quickly later.';
         break;
       case 0:
       default:
@@ -131,11 +136,7 @@ class _MyLearningViewState extends State<MyLearningView> {
                 color: AppTheme.secondaryColor.withValues(alpha: 0.12),
                 shape: BoxShape.circle,
               ),
-              child: Icon(
-                icon,
-                size: 44,
-                color: AppTheme.secondaryColor,
-              ),
+              child: Icon(icon, size: 44, color: AppTheme.secondaryColor),
             ),
             const SizedBox(height: 24),
             Text(


### PR DESCRIPTION
💡 What: Added a `Semantics` widget wrapping the `InkWell` used for the custom tab buttons in the `MyLearningView`.
🎯 Why: Screen readers previously could not correctly identify the custom tab buttons as interactive elements or distinguish which tab was currently active, degrading the experience for users relying on assistive technologies.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen readers now correctly announce the tabs as buttons and identify the selected state using the `selected` property.

---
*PR created automatically by Jules for task [16119365319528477172](https://jules.google.com/task/16119365319528477172) started by @manupawickramasinghe*