### PR TITLE
🎨 Palette: Add accessibility semantics to profile settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,6 @@
 ## 2026-05-04 - Wrap Custom Tab Buttons in Semantics
 **Learning:** In Flutter, when building custom tab controls or bottom navigation items using `InkWell` inside a container (like the tabs in My Learning), screen readers won't automatically know they are interactive buttons or which one is active.
 **Action:** Always wrap the `InkWell` of custom tab buttons in a `Semantics` widget. Set `button: true` to announce it's clickable and `selected: isSelected` to announce its active state.
+## 2024-05-30 - Replace GestureDetector with Material+InkWell for Interactive Elements
+**Learning:** Using `GestureDetector` for interactive widgets like cards, chips, and navigation items fails to provide visual tap feedback and misses out on implicit accessibility semantics (like screen readers identifying the element as a button).
+**Action:** When wrapping a widget to make it interactive, prefer using `Material` combined with `InkWell` inside the container to automatically provide visual ripple effects and implicit semantic button traits.

--- a/lib/views/profile/profile_view.dart
+++ b/lib/views/profile/profile_view.dart
@@ -236,8 +236,10 @@ class ProfileView extends StatelessWidget {
                   children: [
                     Material(
                       color: Colors.transparent,
-                      child: InkWell(
-                        borderRadius: index == 0 && items.length == 1
+                      child: Semantics(
+                        button: true,
+                        child: InkWell(
+                          borderRadius: index == 0 && items.length == 1
                             ? BorderRadius.circular(16)
                             : index == 0
                             ? const BorderRadius.vertical(
@@ -280,6 +282,7 @@ class ProfileView extends StatelessWidget {
                           ),
                         ),
                       ),
+                    ),
                     ),
                     if (index < items.length - 1)
                       Divider(


### PR DESCRIPTION
💡 **What**: Wrapped the `InkWell` components for the setting list items in `lib/views/profile/profile_view.dart` within a `Semantics` widget.
🎯 **Why**: Screen readers need explicit traits to identify interactive list items correctly. Wrapping `InkWell` inside `Semantics` properly exposes its semantic button traits to assistive technology.
📸 **Before/After**: Visually, the settings page remains exactly the same. But internally, the list items now communicate correctly with screen readers.
♿ **Accessibility**: Enhanced accessibility by adding explicit `button: true` semantics. Now, setting items like 'Edit Profile' and 'Appearance' will be announced as buttons to screen reader users instead of just plain text.

---
*PR created automatically by Jules for task [9627297856572015540](https://jules.google.com/task/9627297856572015540) started by @manupawickramasinghe*