### PR TITLE
🎨 Palette: [UX improvement] Add async loading semantic state to Enroll button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -55,3 +55,6 @@
 ## 2024-05-30 - Replace GestureDetector with Material+InkWell for Interactive Elements
 **Learning:** Using `GestureDetector` for interactive widgets like cards, chips, and navigation items fails to provide visual tap feedback and misses out on implicit accessibility semantics (like screen readers identifying the element as a button).
 **Action:** When wrapping a widget to make it interactive, prefer using `Material` combined with `InkWell` inside the container to automatically provide visual ripple effects and implicit semantic button traits.
+## 2024-05-31 - [Form Accessibility and Feedback]
+**Learning:** Found that when buttons submit forms using `GlassButton` or similar custom buttons, if they only change opacity to indicate an inactive/loading state, it may be insufficient for accessibility and clear user feedback, especially without an ARIA label or `Semantics` equivalent in Flutter. Even for actions simulating a network request, lacking a visual loading state makes the interaction feel unresponsive.
+**Action:** Always ensure buttons used for async actions show a visible loading state (like `CircularProgressIndicator`) and have explicit `Semantics` or descriptive labels to indicate their current state (e.g., 'Loading, please wait') to screen readers. For simulated actions, add a brief delay and utilize the button's native `isLoading` state.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -22,6 +22,7 @@ class _CourseDetailViewState extends State<CourseDetailView> {
     contentCollection: 'courses',
   );
   late Stream<List<Review>> _reviewsStream;
+  bool _isEnrolling = false;
 
   @override
   void initState() {
@@ -722,7 +723,12 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                 ),
               ),
               GlassButton(
-                onPressed: () {
+                isLoading: _isEnrolling,
+                onPressed: () async {
+                  setState(() => _isEnrolling = true);
+                  await Future.delayed(const Duration(seconds: 1));
+                  if (!mounted) return;
+                  setState(() => _isEnrolling = false);
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: const Text('Enrolled successfully!'),


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add async loading semantic state to Enroll button

💡 What: Updated the "Enroll Now" GlassButton in CourseDetailView to track an internal `_isEnrolling` state. The button now simulates a brief network request and automatically leverages `GlassButton`'s native loading UI (`CircularProgressIndicator`) and semantics.
🎯 Why: Previously, the mock action fired instantly and merely showed a SnackBar. Real-world users expect an interactive, responsive button that visually communicates loading during network operations. Without visual or semantic feedback, the app feels unresponsive.
♿ Accessibility: Triggering `isLoading` on the `GlassButton` natively updates its internal `Semantics` block, dynamically announcing the loading state to screen readers.

---
*PR created automatically by Jules for task [5617337840545925295](https://jules.google.com/task/5617337840545925295) started by @manupawickramasinghe*