### PR TITLE
🎨 Palette: Add feedback for lesson item tap

### DIFF
--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -624,7 +624,17 @@ class _CourseDetailViewState extends State<CourseDetailView> {
           color: Colors.transparent,
           child: InkWell(
             borderRadius: BorderRadius.circular(14),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('Lesson playback coming soon!'),
+                  behavior: SnackBarBehavior.floating,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              );
+            },
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Row(


### PR DESCRIPTION
💡 What: Added a `SnackBar` notification to the empty `onTap` callback of lesson items in the course detail view.
🎯 Why: Prevents the interface from feeling broken by providing immediate feedback to the user that lesson playback is coming soon.
♿ Accessibility: The `SnackBar` message makes the interaction outcome clear to users.

---
*PR created automatically by Jules for task [4550008555884181504](https://jules.google.com/task/4550008555884181504) started by @manupawickramasinghe*