### PR TITLE
🧹 [remove unnecessary non-null assertions]

### DIFF
--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -91,14 +91,14 @@ class _ExploreViewState extends State<ExploreView> {
       _filteredVideos = _allVideos.where((v) {
         final matchesSearch = isQueryEmpty ||
             searchRegex!.hasMatch(v.title) ||
-            searchRegex!.hasMatch(v.description);
+            searchRegex.hasMatch(v.description);
         return matchesSearch;
       }).toList();
 
       _filteredCourses = _allCourses.where((c) {
         final matchesSearch = isQueryEmpty ||
             searchRegex!.hasMatch(c.title) ||
-            searchRegex!.hasMatch(c.description);
+            searchRegex.hasMatch(c.description);
         final matchesCategory =
             _selectedCategory == 'All' || c.category == _selectedCategory;
         return matchesSearch && matchesCategory;


### PR DESCRIPTION
🎯 **What:** Removed redundant non-null assertion (`!`) operators on the `searchRegex` variable within the `_filterContent` method of `ExploreView`.
💡 **Why:** The Dart analyzer flagged these as unnecessary because `searchRegex` is already type-promoted to non-null earlier in the same boolean expression (`searchRegex!.hasMatch(...)`). Removing them cleans up the code and eliminates the warnings.
✅ **Verification:** Ran `flutter analyze` to ensure no warnings remain, and ran the full `flutter test` suite to guarantee no functionality regressions.
✨ **Result:** Clean, warning-free code that correctly leverages Dart's sound null safety type promotion without altering application behavior.

---
*PR created automatically by Jules for task [11925807388705703309](https://jules.google.com/task/11925807388705703309) started by @manupawickramasinghe*