### PR TITLE
🎨 Palette: [UX improvement] Disable autocorrect on credential TextFields

### DIFF
--- a/lib/studies/lms/login_screen.dart
+++ b/lib/studies/lms/login_screen.dart
@@ -64,6 +64,7 @@ class _LmsLoginScreenState extends State<LmsLoginScreen> {
               decoration: const InputDecoration(labelText: 'Password'),
               obscureText: true,
               textInputAction: TextInputAction.done,
+              autocorrect: false,
               autofillHints: const [AutofillHints.password],
               onSubmitted: (_) => _login(),
             ),

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -147,6 +147,7 @@ class _LoginViewState extends State<LoginView>
                                   controller: _passwordController,
                                   obscureText: !_isPasswordVisible,
                                   textInputAction: TextInputAction.done,
+                                  autocorrect: false,
                                   autofillHints: const [AutofillHints.password],
                                   style: const TextStyle(color: Colors.white),
                                   onSubmitted: (_) {

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -145,6 +145,7 @@ class _SignupViewState extends State<SignupView>
                                   controller: _nameController,
                                   textInputAction: TextInputAction.next,
                                   textCapitalization: TextCapitalization.words,
+                                  autocorrect: false,
                                   autofillHints: const [AutofillHints.name],
                                   style: const TextStyle(color: Colors.white),
                                   decoration: const InputDecoration(
@@ -170,6 +171,7 @@ class _SignupViewState extends State<SignupView>
                                   controller: _passwordController,
                                   obscureText: !_isPasswordVisible,
                                   textInputAction: TextInputAction.done,
+                                  autocorrect: false,
                                   autofillHints: const [
                                     AutofillHints.newPassword,
                                   ],


### PR DESCRIPTION
💡 What: Disabled `autocorrect` on password and name `TextField`s across the application's authentication screens.
🎯 Why: Autocorrect can interfere with entering passwords or names (which often aren't dictionary words), leading to a frustrating user experience.
📸 Before/After: N/A (Behavioral change, not visual).
♿ Accessibility: Improves usability and prevents unwanted OS-level modifications to critical credentials during login and signup.

---
*PR created automatically by Jules for task [8105043922796422874](https://jules.google.com/task/8105043922796422874) started by @manupawickramasinghe*