### PR TITLE
⚡ Bolt: [performance improvement] Prevent redundant list allocation for pre-sorted Firestore data

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -76,3 +76,6 @@
 ## 2024-11-20 - Skip Unnecessary Filtering and Iterations
 **Learning:** In Dart/Flutter apps displaying large filtered lists, using `.where(...).toList()` unnecessarily allocates a completely new list structure even when the active filters do nothing (e.g., empty search string, "All" category). This places preventable pressure on the garbage collector and burns CPU cycles with $O(N)$ operations.
 **Action:** When creating filtered lists inside widget `build` or state updates, short-circuit the filter logic if the filter is empty. For empty filters, simply assign the original reference to the filtered variable instead of executing an $O(N)$ list traversal.
+## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
+**Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
+**Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -75,10 +75,12 @@ class _ReviewsViewState extends State<ReviewsView> {
   }
 
   List<Review> _sorted(List<Review> reviews) {
-    final list = List<Review>.from(reviews);
-    if (_sortBy == _SortBy.topRated) {
-      list.sort((a, b) => b.rating.compareTo(a.rating));
+    if (_sortBy == _SortBy.newest) {
+      // ⚡ Bolt: Prevent O(N) list allocation and copying when the default sort (Newest First) is already applied by the Firestore query.
+      return reviews;
     }
+    final list = List<Review>.from(reviews);
+    list.sort((a, b) => b.rating.compareTo(a.rating));
     return list;
   }
 


### PR DESCRIPTION
💡 **What**: Short-circuited the `_sorted` method in `ReviewsView` to return the original `reviews` list when sorting by newest.

🎯 **Why**: The `getReviews` stream in `ReviewService` already yields a list pre-sorted by `createdAt` descending. Prior to this change, `ReviewsView` unconditionally invoked `List.from(reviews)` on every frame rebuild and stream emission, which created unnecessary $O(N)$ object allocations and caused preventable garbage collection pressure.

📊 **Impact**: Reduces list allocation overhead by 100% when using the default sort method (Newest). Drops GC thrashing associated with list replication for potentially large review datasets.

🔬 **Measurement**: Ensured tests pass successfully and `flutter analyze` shows no new errors. Evaluated visually using `flutter test test/`.

---
*PR created automatically by Jules for task [16916682703391183418](https://jules.google.com/task/16916682703391183418) started by @manupawickramasinghe*