### PR TITLE
🧪 Add unit tests for Video.fromFirestore

### DIFF
--- a/test/models/video_test.dart
+++ b/test/models/video_test.dart
@@ -1,5 +1,20 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hackston_lms/models/video.dart';
+
+class FakeDocumentSnapshot extends Fake
+    implements DocumentSnapshot<Map<String, dynamic>> {
+  final String _id;
+  final Map<String, dynamic>? _data;
+
+  FakeDocumentSnapshot(this._id, this._data);
+
+  @override
+  String get id => _id;
+
+  @override
+  Map<String, dynamic>? data() => _data;
+}
 
 void main() {
   group('Video.fromJson', () {
@@ -77,6 +92,72 @@ void main() {
       final video = Video.fromJson(json);
 
       expect(video.id, '');
+      expect(video.title, 'Untitled');
+      expect(video.description, '');
+      expect(video.videoUrl, '');
+      expect(video.thumbnailUrl, isNull);
+      expect(video.duration, isNull);
+    });
+  });
+
+  group('Video.fromFirestore', () {
+    test('parses fully populated DocumentSnapshot correctly', () {
+      final doc = FakeDocumentSnapshot('vid123', {
+        'title': 'Test Video',
+        'description': 'A comprehensive test video',
+        'videoUrl': 'https://example.com/video.mp4',
+        'thumbnailUrl': 'https://example.com/thumb.jpg',
+        'duration': '10:00',
+      });
+
+      final video = Video.fromFirestore(doc);
+
+      expect(video.id, 'vid123');
+      expect(video.title, 'Test Video');
+      expect(video.description, 'A comprehensive test video');
+      expect(video.videoUrl, 'https://example.com/video.mp4');
+      expect(video.thumbnailUrl, 'https://example.com/thumb.jpg');
+      expect(video.duration, '10:00');
+    });
+
+    test('handles missing optional fields and provides defaults', () {
+      final doc = FakeDocumentSnapshot('vid456', <String, dynamic>{});
+
+      final video = Video.fromFirestore(doc);
+
+      expect(video.id, 'vid456');
+      expect(video.title, 'Untitled');
+      expect(video.description, '');
+      expect(video.videoUrl, '');
+      expect(video.thumbnailUrl, isNull);
+      expect(video.duration, isNull);
+    });
+
+    test('handles null values for optional fields and provides defaults', () {
+      final doc = FakeDocumentSnapshot('vid789', {
+        'title': null,
+        'description': null,
+        'videoUrl': null,
+        'thumbnailUrl': null,
+        'duration': null,
+      });
+
+      final video = Video.fromFirestore(doc);
+
+      expect(video.id, 'vid789');
+      expect(video.title, 'Untitled');
+      expect(video.description, '');
+      expect(video.videoUrl, '');
+      expect(video.thumbnailUrl, isNull);
+      expect(video.duration, isNull);
+    });
+
+    test('handles null data() by providing defaults', () {
+      final doc = FakeDocumentSnapshot('vid000', null);
+
+      final video = Video.fromFirestore(doc);
+
+      expect(video.id, 'vid000');
       expect(video.title, 'Untitled');
       expect(video.description, '');
       expect(video.videoUrl, '');


### PR DESCRIPTION
🎯 **What:** The `Video.fromFirestore` factory method in `lib/models/video.dart` was previously untested, lacking unit tests to ensure it correctly parses `DocumentSnapshot` data into `Video` objects.

📊 **Coverage:** Added a new test group `Video.fromFirestore` to `test/models/video_test.dart`. Scenarios tested include:
- A fully populated `DocumentSnapshot` (happy path).
- A `DocumentSnapshot` with missing optional fields to verify defaults are assigned ('Untitled', '').
- A `DocumentSnapshot` with explicit `null` values for optional fields to verify defaults are assigned.
- A `DocumentSnapshot` where `data()` returns `null` entirely.

✨ **Result:** Improved test coverage for the `Video` model, ensuring safe parsing of Firestore data, and safeguarding against regressions if the `Video` model or factory constructor is refactored.

---
*PR created automatically by Jules for task [13646240923871187184](https://jules.google.com/task/13646240923871187184) started by @manupawickramasinghe*