### PR TITLE
🔒 Fix data leakage in authentication error messages

### DIFF
--- a/lib/viewmodels/auth_viewmodel.dart
+++ b/lib/viewmodels/auth_viewmodel.dart
@@ -76,7 +76,10 @@ class AuthViewModel extends ChangeNotifier {
       case 'invalid-credential':
         return 'Invalid email or password.';
       default:
-        return e.message ?? 'Authentication failed.';
+        if (kDebugMode) {
+          debugPrint('Unhandled FirebaseAuthException: ${e.message}');
+        }
+        return 'Authentication failed.';
     }
   }
 


### PR DESCRIPTION
🎯 **What:** The raw Firebase exception message was being exposed to the UI when an unhandled authentication error occurred.

⚠️ **Risk:** Sensitive internal system details, potentially including database paths, user details, or precise error mechanics, could be exposed to end users, facilitating targeted attacks or unauthorized information gathering.

🛡️ **Solution:** Modified `_parseFirebaseError` in `AuthViewModel` to return a generic "Authentication failed." message to the user for unhandled errors. To ensure developers can still effectively debug issues, the raw `e.message` is safely logged using `debugPrint` behind a `kDebugMode` check, which is entirely stripped from production builds.

---
*PR created automatically by Jules for task [9532500689582991718](https://jules.google.com/task/9532500689582991718) started by @manupawickramasinghe*