### PR TITLE
🧪 [Testing: Add tests for Review.fromFirestore]

### DIFF
--- a/fix_ci.txt
+++ b/fix_ci.txt
@@ -1,0 +1,4 @@
+The CI failed not because of our code, but because of a rate limit error in the `copilot-pull-request-reviewer` workflow ("You've reached your weekly rate limit").
+We don't need to fix any of the application code or tests for this specific error since the code and tests all pass locally.
+
+I'll reply to the user.

--- a/test/models/review_test.dart
+++ b/test/models/review_test.dart
@@ -2,6 +2,17 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hackston_lms/models/review.dart';
 
+class FakeDocumentSnapshot extends Fake implements DocumentSnapshot<Map<String, dynamic>> {
+  @override
+  final String id;
+  final Map<String, dynamic>? _data;
+
+  FakeDocumentSnapshot(this.id, this._data);
+
+  @override
+  Map<String, dynamic>? data() => _data;
+}
+
 void main() {
   group('Review.toMap', () {
     test('correctly maps all properties when userPhotoUrl is provided', () {
@@ -51,6 +62,59 @@ void main() {
       expect(map['comment'], 'Great course!');
       expect(map['createdAt'], isA<Timestamp>());
       expect((map['createdAt'] as Timestamp).toDate(), now);
+    });
+  });
+
+  group('Review.fromFirestore', () {
+    test('parses full data correctly', () {
+      final now = DateTime.now();
+      final doc = FakeDocumentSnapshot('review123', {
+        'userId': 'user123',
+        'userName': 'Test User',
+        'userPhotoUrl': 'https://example.com/photo.png',
+        'rating': 4.5,
+        'comment': 'Great course!',
+        'createdAt': Timestamp.fromDate(now),
+      });
+
+      final review = Review.fromFirestore(doc);
+
+      expect(review.id, 'review123');
+      expect(review.userId, 'user123');
+      expect(review.userName, 'Test User');
+      expect(review.userPhotoUrl, 'https://example.com/photo.png');
+      expect(review.rating, 4.5);
+      expect(review.comment, 'Great course!');
+      expect(review.createdAt, now);
+    });
+
+    test('uses default values when data is missing', () {
+      final doc = FakeDocumentSnapshot('review123', {});
+
+      final review = Review.fromFirestore(doc);
+
+      expect(review.id, 'review123');
+      expect(review.userId, '');
+      expect(review.userName, 'Anonymous');
+      expect(review.userPhotoUrl, isNull);
+      expect(review.rating, 0.0);
+      expect(review.comment, '');
+      // createdAt defaults to DateTime.now(), so we check if it's recent
+      expect(DateTime.now().difference(review.createdAt).inSeconds, lessThan(2));
+    });
+
+    test('handles null data correctly (if snapshot.data() is null)', () {
+      final doc = FakeDocumentSnapshot('review123', null);
+
+      final review = Review.fromFirestore(doc);
+
+      expect(review.id, 'review123');
+      expect(review.userId, '');
+      expect(review.userName, 'Anonymous');
+      expect(review.userPhotoUrl, isNull);
+      expect(review.rating, 0.0);
+      expect(review.comment, '');
+      expect(DateTime.now().difference(review.createdAt).inSeconds, lessThan(2));
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** The `Review.fromFirestore` factory method in `lib/models/review.dart` was previously untested, leaving a coverage gap for how the `Review` model parses raw Firestore data and handles defaults.

📊 **Coverage:** This PR adds a `FakeDocumentSnapshot` to mock Firestore responses and includes unit tests covering:
- Parsing fully populated Firestore document data correctly.
- Safely handling empty data structures and falling back to default properties.
- Properly managing a completely `null` `DocumentSnapshot.data()` response.

✨ **Result:** Test coverage for `lib/models/review.dart` is improved, ensuring the data serialization layer from Firestore is robust against malformed or missing data.

---
*PR created automatically by Jules for task [14642789959275210761](https://jules.google.com/task/14642789959275210761) started by @manupawickramasinghe*