### PR TITLE
⚡ Bolt: Memoize review rating computations during rebuilds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
 **Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
 **Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.
+## 2024-05-24 - [Avoid redundant average calculations in build method using local caching]
+**Learning:** O(N) calculations (like summing reviews to find the average rating) in Dart within widget build loops should be avoided, especially inside components receiving frequently updating streams. We can use `identical(reviews, _cachedReviews)` to safely check if the list reference has changed and skip recounting when the list is identical to a prior frame.
+**Action:** In widgets parsing streams or lists, introduce local caching variables for aggregates or complex data manipulation, updating them only when the input object references change to avoid redundant calculations.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -23,6 +23,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   );
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
 
   @override
   void initState() {
@@ -367,13 +369,17 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               }
 
               // Rating summary bar
-              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-              // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              if (!identical(reviews, _cachedReviews)) {
+                // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
+                // to avoid allocating a closure on every widget rebuild
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviews = reviews;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              final avg = _cachedAvg;
 
               return Column(
                 children: [

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -35,6 +35,9 @@ class _ReviewsViewState extends State<ReviewsView> {
   bool _checkingUserReview = true;
   _SortBy _sortBy = _SortBy.newest;
   late Stream<List<Review>> _reviewsStream;
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+  Map<int, int> _cachedCounts = {5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
 
   @override
   void initState() {
@@ -307,18 +310,25 @@ class _ReviewsViewState extends State<ReviewsView> {
   // ── Rating summary ─────────────────────────────────────────────────────────
 
   Widget _buildRatingSummary(List<Review> reviews) {
-    var sum = 0.0;
-    final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
+    if (!identical(reviews, _cachedReviews)) {
+      var sum = 0.0;
+      final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
 
-    // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
-    // and avoid creating closures inside the render loop via .fold()
-    for (final r in reviews) {
-      sum += r.rating;
-      final key = r.rating.round().clamp(1, 5);
-      counts[key] = (counts[key] ?? 0) + 1;
+      // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
+      // and avoid creating closures inside the render loop via .fold()
+      for (final r in reviews) {
+        sum += r.rating;
+        final key = r.rating.round().clamp(1, 5);
+        counts[key] = (counts[key] ?? 0) + 1;
+      }
+
+      _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+      _cachedCounts = counts;
+      _cachedReviews = reviews;
     }
 
-    final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+    final avg = _cachedAvg;
+    final counts = _cachedCounts;
 
     return GlassCard(
       padding: const EdgeInsets.all(20),

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -25,6 +25,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
     contentCollection: 'videos',
   );
   late Stream<List<Review>> _reviewsStream;
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
 
   @override
   void initState() {
@@ -348,13 +350,17 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-            // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            if (!identical(reviews, _cachedReviews)) {
+              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
+              // to avoid allocating a closure on every widget rebuild
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+            final avg = _cachedAvg;
 
             return Column(
               children: [


### PR DESCRIPTION
💡 **What:**
Implemented manual memoization for the review rating calculations (average ratings and star distribution counts) in `course_detail_view.dart`, `reviews_view.dart`, and `video_player_view.dart`. Added caching variables (`_cachedReviews`, `_cachedAvg`, `_cachedCounts`) and a reference check using `identical(reviews, _cachedReviews)` to only perform the O(N) calculations when the stream emits a new list.

🎯 **Why:**
These calculations were previously running on every single widget `build`, even if the underlying `reviews` data had not changed. Because they receive data from a `StreamBuilder`, the parent layout or animations might trigger frequent rebuilds, causing redundant O(N) calculations and closure allocations that unnecessarily increased CPU usage and garbage collection pressure.

📊 **Impact:**
Reduces the time complexity of building these widgets from O(N) to O(1) on subsequent rebuilds where the data hasn't changed. This should decrease CPU overhead during scroll events and animations for views displaying review data.

🔬 **Measurement:**
We can verify the improvement by placing a log or trace inside the calculation blocks. Previously, it would fire repeatedly during a rebuild; now it will only fire when the actual list reference is updated via a stream event. Test suites pass.

---
*PR created automatically by Jules for task [4259857699944180030](https://jules.google.com/task/4259857699944180030) started by @manupawickramasinghe*