### PR TITLE
⚡ Bolt: optimize StreamBuilder widget rebuild list allocations

### DIFF
--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -24,6 +24,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
 
+  List<Review>? _cachedReviews;
+  double _cachedAverage = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -367,13 +370,17 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               }
 
               // Rating summary bar
-              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-              // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              // ⚡ Bolt: Memoize expensive O(N) list operations by caching the list reference and result.
+              // Use Dart's identical() for an O(1) identity check to quickly skip recalculations on widget rebuilds.
+              if (!identical(reviews, _cachedReviews)) {
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                _cachedAverage = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviews = reviews;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              final avg = _cachedAverage;
 
               return Column(
                 children: [

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -26,6 +26,9 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   );
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedReviews;
+  double _cachedAverage = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -348,13 +351,17 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-            // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            // ⚡ Bolt: Memoize expensive O(N) list operations by caching the list reference and result.
+            // Use Dart's identical() for an O(1) identity check to quickly skip recalculations on widget rebuilds.
+            if (!identical(reviews, _cachedReviews)) {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAverage = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+            final avg = _cachedAverage;
 
             return Column(
               children: [


### PR DESCRIPTION
💡 What:
Implemented an `identical()` caching check for review averages in the `CourseDetailView` and `VideoPlayerView` `StreamBuilder` widgets.

🎯 Why:
The `StreamBuilder` calculates the sum and average rating from a list of reviews on every widget rebuild (e.g. from local UI updates or animations). By caching the `reviews` list reference and result, we avoid O(N) calculations and redundant allocations if the underlying list data from the stream has not changed.

📊 Impact:
Eliminates O(N) iterations inside the widget rendering loop on unrelated rebuilds. Time complexity for rendering drops from O(N) to O(1) when the stream output is unchanged.

🔬 Measurement:
Use Dart DevTools CPU Profiler to measure the time spent inside the `build` method of `_CourseDetailViewState` and `_VideoPlayerViewState` before and after this change when local UI interactions trigger rebuilds.

---
*PR created automatically by Jules for task [3430958522125881869](https://jules.google.com/task/3430958522125881869) started by @manupawickramasinghe*