### PR TITLE
⚡ Bolt: [performance improvement] Memoize list rebuild operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
 **Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
 **Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.
+## 2024-05-30 - Memoization of Iterations inside StreamBuilders
+**Learning:** In Flutter, StreamBuilders can emit the same instances of data during structural parent widget rebuilds. Re-running O(N) aggregate calculations (like averages or sums) on every widget rebuild using loops on these data sets is an anti-pattern. While the loops do not allocate extra memory like `.fold`, they still cost CPU time.
+**Action:** Always memoize computationally expensive (O(N), O(N log N)) iterations or sorts on collection datasets in widget build methods. Maintain the original list reference in state via `List? _cachedOriginalList` and compute the calculation on an `identical(incomingList, _cachedOriginalList)` identity check to return a cached result.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -24,6 +24,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
 
+  List<Review>? _cachedReviewsForAvg;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -367,13 +370,19 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               }
 
               // Rating summary bar
-              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-              // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              // ⚡ Bolt: Memoize O(N) average rating calculation using identical check
+              double avg;
+              if (identical(reviews, _cachedReviewsForAvg)) {
+                avg = _cachedAvg;
+              } else {
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviewsForAvg = reviews;
+                _cachedAvg = avg;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
 
               return Column(
                 children: [

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -36,6 +36,10 @@ class _ReviewsViewState extends State<ReviewsView> {
   _SortBy _sortBy = _SortBy.newest;
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedOriginalReviews;
+  List<Review> _cachedSortedReviews = [];
+  _SortBy? _cachedSortBy;
+
   @override
   void initState() {
     super.initState();
@@ -79,8 +83,19 @@ class _ReviewsViewState extends State<ReviewsView> {
       // ⚡ Bolt: Prevent O(N) list allocation and copying when the default sort (Newest First) is already applied by the Firestore query.
       return reviews;
     }
+
+    // ⚡ Bolt: Memoize O(N log N) sorting using O(1) identical check
+    if (identical(reviews, _cachedOriginalReviews) && _sortBy == _cachedSortBy) {
+      return _cachedSortedReviews;
+    }
+
     final list = List<Review>.from(reviews);
     list.sort((a, b) => b.rating.compareTo(a.rating));
+
+    _cachedOriginalReviews = reviews;
+    _cachedSortedReviews = list;
+    _cachedSortBy = _sortBy;
+
     return list;
   }
 

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -26,6 +26,9 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   );
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedReviewsForAvg;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -348,13 +351,19 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-            // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            // ⚡ Bolt: Memoize O(N) average rating calculation using identical check
+            double avg;
+            if (identical(reviews, _cachedReviewsForAvg)) {
+              avg = _cachedAvg;
+            } else {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviewsForAvg = reviews;
+              _cachedAvg = avg;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
 
             return Column(
               children: [


### PR DESCRIPTION
💡 **What:**
Memoized the O(N) loop operations (calculating the average rating) in `course_detail_view.dart` and `video_player_view.dart`, and the O(N log N) sorting operation in `reviews_view.dart`. This is done using Dart's `identical()` reference check to skip recomputing when the underlying stream data reference hasn't changed.

🎯 **Why:**
StreamBuilders rebuild their child widgets during state changes and structural layout updates. By executing `O(N)` average loops or `O(N log N)` list sorts on every frame rebuild (even when the actual underlying `reviews` array hasn't changed), the UI thread burns unnecessary CPU cycles causing stutter and frame drops. 

📊 **Impact:**
Significantly reduces frame rendering time during UI interactions (like scrolling or popping dialogs) by skipping $O(N)$ arithmetic and list sorting operations entirely. This translates into smoother 60/120fps animations on lower-end devices.

🔬 **Measurement:**
This can be verified by injecting `debugPrint` inside the `if (!identical(...))` fallback block. The calculation will now strictly only run once per real-time stream data emission from Firestore, instead of firing repeatedly every time the widget tree rebuilds.

---
*PR created automatically by Jules for task [8291180614776252238](https://jules.google.com/task/8291180614776252238) started by @manupawickramasinghe*