### PR TITLE
🎨 Palette: Add Semantics to Course and Video cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,6 @@
 ## 2026-05-20 - Explore View Empty State Clear Filters
 **Learning:** Users can get trapped in a 'No results found' state when combining search queries with category filters, requiring multiple manual interactions to reset the view. Adding a single 'Clear Filters' CTA directly in the empty state significantly improves recovery time and UX flow.
 **Action:** Always provide an actionable 'reset' or 'clear' button within empty states that are triggered by active filters or search queries.
+## 2026-05-27 - Semantics for Clickable Content Cards
+**Learning:** When using `InkWell` directly inside custom cards like Course or Video cards, screen readers might only announce the visible text inside without context that it is an interactive element representing a specific item. Adding `button: true` to the `InkWell` itself might not be enough if it contains complex nested UI.
+**Action:** When wrapping a custom content card in an `InkWell`, always wrap the `InkWell` itself in a `Semantics` widget. Set `button: true` and provide a clear, descriptive `label` combining the item type and its name (e.g., `label: "Course: ${course.title}"`) to provide explicit context to assistive technologies.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -426,12 +426,16 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  button: true,
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -505,12 +509,16 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  button: true,
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -456,12 +456,16 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(20),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  button: true,
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(20),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -558,12 +562,16 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  button: true,
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
💡 **What:** Added `Semantics` widgets around the `InkWell` components used for clickable Course and Video cards in `HomeView` and `ExploreView`.
🎯 **Why:** To ensure that screen readers correctly identify these complex custom cards as interactive buttons and explicitly announce their specific content.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen reader users will now hear "Course: [Course Title], Button" instead of disconnected text snippets or silence, significantly improving navigation context.

---
*PR created automatically by Jules for task [11675054710834742515](https://jules.google.com/task/11675054710834742515) started by @manupawickramasinghe*