### PR TITLE
⚡ Bolt: Memoize expensive O(N) array calculations in StreamBuilders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,7 @@
 ## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
 **Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
 **Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.
+
+## 2024-05-28 - Flutter List Memory Footprint
+**Learning:** O(N) array calculations and sorting within `StreamBuilder` logic generate unneeded memory footprint and CPU utilization on every subsequent UI rebuild.
+**Action:** In Flutter, memoize `StreamBuilder` payload outputs using `identical(list, cachedList)` to verify instance references instead of deep-checking payload equality.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -24,6 +24,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
 
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -367,13 +370,16 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               }
 
               // Rating summary bar
-              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-              // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              // ⚡ Bolt: Memoize the average calculation to avoid O(N) operations on every rebuild
+              if (!identical(reviews, _cachedReviews)) {
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviews = reviews;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              final avg = _cachedAvg;
 
               return Column(
                 children: [

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -36,6 +36,15 @@ class _ReviewsViewState extends State<ReviewsView> {
   _SortBy _sortBy = _SortBy.newest;
   late Stream<List<Review>> _reviewsStream;
 
+  // Memoization state
+  List<Review>? _cachedSortSource;
+  List<Review>? _cachedSortResult;
+  _SortBy? _cachedSortBy;
+
+  List<Review>? _cachedSummaryReviews;
+  double _cachedAvg = 0.0;
+  Map<int, int> _cachedCounts = {5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
+
   @override
   void initState() {
     super.initState();
@@ -79,8 +88,21 @@ class _ReviewsViewState extends State<ReviewsView> {
       // ⚡ Bolt: Prevent O(N) list allocation and copying when the default sort (Newest First) is already applied by the Firestore query.
       return reviews;
     }
+
+    // ⚡ Bolt: Memoize the sorting calculation
+    if (identical(reviews, _cachedSortSource) &&
+        _sortBy == _cachedSortBy &&
+        _cachedSortResult != null) {
+      return _cachedSortResult!;
+    }
+
     final list = List<Review>.from(reviews);
     list.sort((a, b) => b.rating.compareTo(a.rating));
+
+    _cachedSortSource = reviews;
+    _cachedSortResult = list;
+    _cachedSortBy = _sortBy;
+
     return list;
   }
 
@@ -307,18 +329,26 @@ class _ReviewsViewState extends State<ReviewsView> {
   // ── Rating summary ─────────────────────────────────────────────────────────
 
   Widget _buildRatingSummary(List<Review> reviews) {
-    var sum = 0.0;
-    final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
+    // ⚡ Bolt: Memoize the summary aggregations to avoid O(N) operations on every rebuild
+    if (!identical(reviews, _cachedSummaryReviews)) {
+      var sum = 0.0;
+      final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
 
-    // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
-    // and avoid creating closures inside the render loop via .fold()
-    for (final r in reviews) {
-      sum += r.rating;
-      final key = r.rating.round().clamp(1, 5);
-      counts[key] = (counts[key] ?? 0) + 1;
+      // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
+      // and avoid creating closures inside the render loop via .fold()
+      for (final r in reviews) {
+        sum += r.rating;
+        final key = r.rating.round().clamp(1, 5);
+        counts[key] = (counts[key] ?? 0) + 1;
+      }
+
+      _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+      _cachedCounts = counts;
+      _cachedSummaryReviews = reviews;
     }
 
-    final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+    final avg = _cachedAvg;
+    final counts = _cachedCounts;
 
     return GlassCard(
       padding: const EdgeInsets.all(20),

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -90,26 +90,24 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       // Optimization: Skip O(N) list traversal and object allocation when there are no active filters
-      _filteredVideos =
-          isQueryEmpty
-              ? _allVideos
-              : _allVideos.where((v) {
-                  return searchRegex!.hasMatch(v.title) ||
-                      searchRegex.hasMatch(v.description);
-                }).toList();
+      _filteredVideos = isQueryEmpty
+          ? _allVideos
+          : _allVideos.where((v) {
+              return searchRegex!.hasMatch(v.title) ||
+                  searchRegex.hasMatch(v.description);
+            }).toList();
 
-      _filteredCourses =
-          (isQueryEmpty && isCategoryAll)
-              ? _allCourses
-              : _allCourses.where((c) {
-                  final matchesSearch =
-                      isQueryEmpty ||
-                      searchRegex!.hasMatch(c.title) ||
-                      searchRegex.hasMatch(c.description);
-                  final matchesCategory =
-                      isCategoryAll || c.category == _selectedCategory;
-                  return matchesSearch && matchesCategory;
-                }).toList();
+      _filteredCourses = (isQueryEmpty && isCategoryAll)
+          ? _allCourses
+          : _allCourses.where((c) {
+              final matchesSearch =
+                  isQueryEmpty ||
+                  searchRegex!.hasMatch(c.title) ||
+                  searchRegex.hasMatch(c.description);
+              final matchesCategory =
+                  isCategoryAll || c.category == _selectedCategory;
+              return matchesSearch && matchesCategory;
+            }).toList();
     });
   }
 

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -26,6 +26,9 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   );
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -348,13 +351,16 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-            // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            // ⚡ Bolt: Memoize the average calculation to avoid O(N) operations on every rebuild
+            if (!identical(reviews, _cachedReviews)) {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+            final avg = _cachedAvg;
 
             return Column(
               children: [


### PR DESCRIPTION
💡 **What**: Added reference-based memoization to `CourseDetailView`, `VideoPlayerView`, and `ReviewsView` using Dart's `identical()` function to cache the results of list processing logic within `StreamBuilder` widgets.
🎯 **Why**: When a widget containing a `StreamBuilder` rebuilds (e.g., due to scroll events, animations, or UI state changes outside the stream), the `builder` function is re-executed. Previously, this caused O(N) tasks like calculating average ratings, counting rating frequencies, and O(N log N) sorting to run redundantly on the exact same dataset, wasting CPU cycles and memory allocations.
📊 **Impact**: Eliminates redundant O(N) list traversals and O(N log N) sorting during widget rebuilds. Reduces garbage collection pressure and main thread CPU usage, leading to smoother scrolling and animations in detail views.
🔬 **Measurement**: Verified by placing a print statement inside the calculation loops and observing that it no longer triggers on layout shifts or minor state changes when the stream's data instance hasn't changed. Evaluated regressions using `flutter test`.

---
*PR created automatically by Jules for task [5360092920304387567](https://jules.google.com/task/5360092920304387567) started by @manupawickramasinghe*