### PR TITLE
🎨 Palette: [UX improvement] Add hover tooltip to profile avatar button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-12 - Add tooltip to icon-only back buttons
 **Learning:** In Flutter, ensure icon-only buttons (like `IconButton`) always have a descriptive `tooltip` attribute added. This provides proper accessibility labels for screen readers and helpful context for mouse hover states.
 **Action:** Always include a `tooltip` string on `IconButton` widgets, especially when they act as standalone navigational elements.
+
+## 2024-05-23 - Retaining explicit semantics on parent containers
+**Learning:** In Flutter, while `InkWell` provides implicit button semantics, wrapping a structural layout widget (like `Container`) with `Semantics` requires retaining the `button: true` trait if that container acts as the overall interactive target, even if there is an `InkWell` deeper within it. Removing the explicit button semantics from the wrapping `Container` removes the button trait entirely from screen reader announcements.
+**Action:** When auditing redundant `button: true` traits, never remove them from `Semantics` widgets wrapping structural components like `Container`. Instead, look to add appropriate visual and auditory feedback, such as `Tooltip`, to icon-only custom widgets.

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -141,41 +141,44 @@ class _HomeViewState extends State<HomeView> {
             ],
           ),
         ),
-        Semantics(
-          label: 'Profile settings',
-          button: true,
-          child: Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              gradient: AppTheme.primaryGradient,
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Material(
-              color: Colors.transparent,
-              child: InkWell(
+        Tooltip(
+          message: 'Profile settings',
+          child: Semantics(
+            label: 'Profile settings',
+            button: true,
+            child: Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                gradient: AppTheme.primaryGradient,
                 borderRadius: BorderRadius.circular(16),
-                onTap: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: const Text('Profile settings coming soon!'),
-                      behavior: SnackBarBehavior.floating,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                    ),
-                  );
-                },
-                child: auth.photoUrl != null
-                    ? ClipRRect(
-                        borderRadius: BorderRadius.circular(16),
-                        child: CachedNetworkImage(
-                          imageUrl: auth.photoUrl!,
-                          fit: BoxFit.cover,
-                          errorWidget: (_, __, ___) => _buildInitials(auth),
+              ),
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(16),
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('Profile settings coming soon!'),
+                        behavior: SnackBarBehavior.floating,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
                         ),
-                      )
-                    : _buildInitials(auth),
+                      ),
+                    );
+                  },
+                  child: auth.photoUrl != null
+                      ? ClipRRect(
+                          borderRadius: BorderRadius.circular(16),
+                          child: CachedNetworkImage(
+                            imageUrl: auth.photoUrl!,
+                            fit: BoxFit.cover,
+                            errorWidget: (_, __, ___) => _buildInitials(auth),
+                          ),
+                        )
+                      : _buildInitials(auth),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
💡 **What**: Wrapped the custom profile avatar button in `HomeView` with a `Tooltip` widget showing "Profile settings".
🎯 **Why**: The profile avatar in the home view acts as an interactive button, but because it is composed of a custom `Container` and `InkWell` without a text label, it lacked visual feedback on hover for web/desktop users.
📸 **Before/After**: Hovering over the profile picture previously showed no tooltip. It now displays "Profile settings".
♿ **Accessibility**: Provides immediate visual context and tooltips for users utilizing mouse or pointer-based navigation, complementing the existing semantic label for screen readers.

---
*PR created automatically by Jules for task [16934898156739457484](https://jules.google.com/task/16934898156739457484) started by @manupawickramasinghe*