### PR TITLE
⚡ Bolt: Memoize StreamBuilder O(N) Operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
 **Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
 **Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.
+## 2026-06-01 - [Memoizing StreamBuilder O(N) Operations]
+**Learning:** [identical() provides an O(1) way to check if a Stream has yielded a new dataset, allowing expensive O(N) derivations inside a StreamBuilder to be skipped on normal widget rebuilds.]
+**Action:** [Use identical(newList, _cachedList) to memoize expensive operations on Stream data in Flutter build methods.]

--- a/lib/core/glass_widgets.dart
+++ b/lib/core/glass_widgets.dart
@@ -340,9 +340,8 @@ class _NavItem extends StatelessWidget {
                 children: [
                   Icon(
                     icon,
-                    color: isSelected
-                        ? AppTheme.primaryColor
-                        : AppTheme.textMuted,
+                    color:
+                        isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
                     size: 24,
                   ),
                   const SizedBox(height: 4),
@@ -350,9 +349,8 @@ class _NavItem extends StatelessWidget {
                     label,
                     style: TextStyle(
                       fontSize: 11,
-                      fontWeight: isSelected
-                          ? FontWeight.w600
-                          : FontWeight.w500,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.w500,
                       color: isSelected
                           ? AppTheme.primaryColor
                           : AppTheme.textMuted,

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -31,8 +31,7 @@ class Course {
       rating: (data?['rating'] ?? 0.0).toDouble(),
       category: data?['category'] ?? 'General',
       studentCount: data?['studentCount'] ?? 0,
-      lessons:
-          (data?['lessons'] as List<dynamic>?)
+      lessons: (data?['lessons'] as List<dynamic>?)
               ?.map(
                 (lessonData) =>
                     Lesson.fromJson(lessonData as Map<String, dynamic>),

--- a/lib/services/course_service.dart
+++ b/lib/services/course_service.dart
@@ -6,7 +6,7 @@ class CourseService {
   final FirebaseFirestore _db;
 
   CourseService({FirebaseFirestore? db})
-    : _db = db ?? FirebaseFirestore.instance;
+      : _db = db ?? FirebaseFirestore.instance;
 
   // Optimization: Added optional limit parameter to prevent unbounded reads
   Future<List<Course>> getRecommendedCourses({int? limit}) async {

--- a/lib/services/video_service.dart
+++ b/lib/services/video_service.dart
@@ -6,7 +6,7 @@ class VideoService {
   final FirebaseFirestore _db;
 
   VideoService({FirebaseFirestore? db})
-    : _db = db ?? FirebaseFirestore.instance;
+      : _db = db ?? FirebaseFirestore.instance;
 
   // Optimization: Added optional limit parameter to prevent unbounded reads
   Future<List<Video>> getVideos({int? limit}) async {

--- a/lib/viewmodels/auth_viewmodel.dart
+++ b/lib/viewmodels/auth_viewmodel.dart
@@ -126,8 +126,8 @@ class AuthViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final GoogleSignInAccount? googleUser = await GoogleSignIn.instance
-          .authenticate();
+      final GoogleSignInAccount? googleUser =
+          await GoogleSignIn.instance.authenticate();
       if (googleUser == null) {
         _isLoading = false;
         notifyListeners();

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -31,10 +31,10 @@ class _LoginViewState extends State<LoginView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
-        .animate(
-          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-        );
+    _slideAnim =
+        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
+      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+    );
     _animController.forward();
   }
 

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -30,10 +30,10 @@ class _SignupViewState extends State<SignupView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
-        .animate(
-          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-        );
+    _slideAnim =
+        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
+      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+    );
     _animController.forward();
   }
 

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -24,6 +24,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
 
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -57,9 +60,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   }
 
   Widget _buildAppBar(BuildContext context) {
-    final colors =
-        AppTheme.cardGradients[widget.course.title.length %
-            AppTheme.cardGradients.length];
+    final colors = AppTheme.cardGradients[
+        widget.course.title.length % AppTheme.cardGradients.length];
 
     return SliverAppBar(
       expandedHeight: 260,
@@ -367,13 +369,16 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               }
 
               // Rating summary bar
-              // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-              // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              // ⚡ Bolt: Use identical() to skip O(N) recalculations on normal widget rebuilds
+              if (!identical(reviews, _cachedReviews)) {
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviews = reviews;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              final avg = _cachedAvg;
 
               return Column(
                 children: [
@@ -428,8 +433,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                                               i < avg.floor()
                                                   ? Icons.star_rounded
                                                   : i < avg
-                                                  ? Icons.star_half_rounded
-                                                  : Icons.star_border_rounded,
+                                                      ? Icons.star_half_rounded
+                                                      : Icons
+                                                          .star_border_rounded,
                                               color: Colors.amber,
                                               size: 20,
                                             ),

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -36,6 +36,10 @@ class _ReviewsViewState extends State<ReviewsView> {
   _SortBy _sortBy = _SortBy.newest;
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+  Map<int, int> _cachedCounts = {5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
+
   @override
   void initState() {
     super.initState();
@@ -307,18 +311,26 @@ class _ReviewsViewState extends State<ReviewsView> {
   // ── Rating summary ─────────────────────────────────────────────────────────
 
   Widget _buildRatingSummary(List<Review> reviews) {
-    var sum = 0.0;
-    final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
+    // ⚡ Bolt: Use identical() to skip O(N) recalculations on normal widget rebuilds
+    if (!identical(reviews, _cachedReviews)) {
+      var sum = 0.0;
+      final counts = <int, int>{5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
 
-    // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
-    // and avoid creating closures inside the render loop via .fold()
-    for (final r in reviews) {
-      sum += r.rating;
-      final key = r.rating.round().clamp(1, 5);
-      counts[key] = (counts[key] ?? 0) + 1;
+      // ⚡ Bolt: Single pass loop for both avg and counts to eliminate redundant O(N) traversals
+      // and avoid creating closures inside the render loop via .fold()
+      for (final r in reviews) {
+        sum += r.rating;
+        final key = r.rating.round().clamp(1, 5);
+        counts[key] = (counts[key] ?? 0) + 1;
+      }
+
+      _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+      _cachedCounts = counts;
+      _cachedReviews = reviews;
     }
 
-    final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+    final avg = _cachedAvg;
+    final counts = _cachedCounts;
 
     return GlassCard(
       padding: const EdgeInsets.all(20),
@@ -818,8 +830,8 @@ class _ReviewsViewState extends State<ReviewsView> {
               i < rating.floor()
                   ? Icons.star_rounded
                   : i < rating
-                  ? Icons.star_half_rounded
-                  : Icons.star_border_rounded,
+                      ? Icons.star_half_rounded
+                      : Icons.star_border_rounded,
               color: Colors.amber,
               size: size,
             ),

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -90,26 +90,23 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       // Optimization: Skip O(N) list traversal and object allocation when there are no active filters
-      _filteredVideos =
-          isQueryEmpty
-              ? _allVideos
-              : _allVideos.where((v) {
-                  return searchRegex!.hasMatch(v.title) ||
-                      searchRegex.hasMatch(v.description);
-                }).toList();
+      _filteredVideos = isQueryEmpty
+          ? _allVideos
+          : _allVideos.where((v) {
+              return searchRegex!.hasMatch(v.title) ||
+                  searchRegex.hasMatch(v.description);
+            }).toList();
 
-      _filteredCourses =
-          (isQueryEmpty && isCategoryAll)
-              ? _allCourses
-              : _allCourses.where((c) {
-                  final matchesSearch =
-                      isQueryEmpty ||
-                      searchRegex!.hasMatch(c.title) ||
-                      searchRegex.hasMatch(c.description);
-                  final matchesCategory =
-                      isCategoryAll || c.category == _selectedCategory;
-                  return matchesSearch && matchesCategory;
-                }).toList();
+      _filteredCourses = (isQueryEmpty && isCategoryAll)
+          ? _allCourses
+          : _allCourses.where((c) {
+              final matchesSearch = isQueryEmpty ||
+                  searchRegex!.hasMatch(c.title) ||
+                  searchRegex.hasMatch(c.description);
+              final matchesCategory =
+                  isCategoryAll || c.category == _selectedCategory;
+              return matchesSearch && matchesCategory;
+            }).toList();
     });
   }
 
@@ -192,9 +189,8 @@ class _ExploreViewState extends State<ExploreView> {
                           child: AnimatedContainer(
                             duration: const Duration(milliseconds: 200),
                             decoration: BoxDecoration(
-                              gradient: isSelected
-                                  ? AppTheme.primaryGradient
-                                  : null,
+                              gradient:
+                                  isSelected ? AppTheme.primaryGradient : null,
                               color: isSelected
                                   ? null
                                   : Colors.white.withValues(alpha: 0.08),

--- a/lib/views/profile/profile_view.dart
+++ b/lib/views/profile/profile_view.dart
@@ -252,14 +252,14 @@ class ProfileView extends StatelessWidget {
                           borderRadius: index == 0 && items.length == 1
                               ? BorderRadius.circular(16)
                               : index == 0
-                              ? const BorderRadius.vertical(
-                                  top: Radius.circular(16),
-                                )
-                              : index == items.length - 1
-                              ? const BorderRadius.vertical(
-                                  bottom: Radius.circular(16),
-                                )
-                              : BorderRadius.zero,
+                                  ? const BorderRadius.vertical(
+                                      top: Radius.circular(16),
+                                    )
+                                  : index == items.length - 1
+                                      ? const BorderRadius.vertical(
+                                          bottom: Radius.circular(16),
+                                        )
+                                      : BorderRadius.zero,
                           onTap: items[index].onTap,
                           child: Padding(
                             padding: const EdgeInsets.symmetric(

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -26,6 +26,9 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   );
   late Stream<List<Review>> _reviewsStream;
 
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
+
   @override
   void initState() {
     super.initState();
@@ -348,13 +351,16 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
-            // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            // ⚡ Bolt: Use identical() to skip O(N) recalculations on normal widget rebuilds
+            if (!identical(reviews, _cachedReviews)) {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+            final avg = _cachedAvg;
 
             return Column(
               children: [
@@ -407,8 +413,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                                             i < avg.floor()
                                                 ? Icons.star_rounded
                                                 : i < avg
-                                                ? Icons.star_half_rounded
-                                                : Icons.star_border_rounded,
+                                                    ? Icons.star_half_rounded
+                                                    : Icons.star_border_rounded,
                                             color: Colors.amber,
                                             size: 20,
                                           ),


### PR DESCRIPTION
🎯 What: Added `identical()` checks inside `StreamBuilder` widgets to cache list references and memoize expensive O(N) average and frequency calculations.
💡 Why: When Flutter `StreamBuilder` widgets rebuild during normal widget lifecycles (like scrolling or state changes), they unnecessarily execute O(N) calculations (`var sum = 0.0; for (final r in reviews) sum += r.rating;`) over the existing `snapshot.data` even if the stream hasn't yielded new data. Memoizing this skips the O(N) work on normal build frames.
📊 Impact: Reduces O(N) traversal overhead to O(1) during standard widget frame rebuilds, reducing CPU cycles and improving frame render times.
🔬 Measurement: Verified the logic correctness via the existing test suite and `flutter test`. Performance impact can be measured via Flutter DevTools timeline by observing reduced CPU usage during heavy scrolling of the `ReviewsView`.

---
*PR created automatically by Jules for task [9652075281078321559](https://jules.google.com/task/9652075281078321559) started by @manupawickramasinghe*