### PR TITLE
🎨 Palette: Add specific semantic labels to clickable cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-04-12 - Add tooltip to icon-only back buttons
 **Learning:** In Flutter, ensure icon-only buttons (like `IconButton`) always have a descriptive `tooltip` attribute added. This provides proper accessibility labels for screen readers and helpful context for mouse hover states.
 **Action:** Always include a `tooltip` string on `IconButton` widgets, especially when they act as standalone navigational elements.
+## 2024-06-01 - Specific Semantics for Stacked Clickable Cards
+**Learning:** When building custom clickable cards using a Stack where the InkWell is separated from the visual content (e.g., via Positioned.fill), screen readers may announce a generic "button" without context. Adding a specific, descriptive label to the InkWell's Semantics wrapper prevents unhelpful generic announcements.
+**Action:** Always wrap InkWells used as card overlays in a Semantics widget with a descriptive label reflecting the card's specific content.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -426,12 +426,15 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -505,12 +508,15 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -456,12 +456,15 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(20),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(20),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -558,12 +561,15 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
* 💡 What: Added specific semantic labels (`Semantics(label: ...)`) to clickable Course and Video cards in `home_view.dart` and `explore_view.dart`.
* 🎯 Why: To ensure screen readers announce the specific context of the clickable card (e.g., "Course: [Title]") rather than a generic "button" prompt, preventing unhelpful generic announcements.
* 📸 Before/After: Visuals unchanged.
* ♿ Accessibility: Improved screen reader navigation and context for custom card components.

---
*PR created automatically by Jules for task [9578855704929458163](https://jules.google.com/task/9578855704929458163) started by @manupawickramasinghe*