### PR TITLE
⚡ Bolt: [performance improvement] Memoize O(N) rating calculations in StreamBuilders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-05-20 - [Redundant List Allocations on Pre-sorted Firestore Data]
 **Learning:** The application streams pre-sorted data from Firestore (e.g., reviews sorted by newest). Re-allocating these into new lists (`List.from`) during the widget build cycle for the default sort state causes unnecessary O(N) memory allocations and garbage collection pressure on every stream emission or rebuild.
 **Action:** Always check if the default sort order matches the backend query's sort order. If it does, short-circuit the client-side sorting logic and return the original list reference directly.
+## 2026-06-03 - Memoize O(N) list operations in StreamBuilder
+**Learning:** In Flutter build methods, especially inside StreamBuilder, O(N) list operations can execute redundantly on widget rebuilds even when stream data hasn't changed.
+**Action:** Cache the list reference and result, and use Dart's `identical(newList, _cachedList)` for an O(1) identity check to quickly skip recalculations.

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -23,6 +23,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   );
   late Stream<List<Review>> _reviewsStream;
   bool _isEnrolling = false;
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
 
   @override
   void initState() {
@@ -369,11 +371,15 @@ class _CourseDetailViewState extends State<CourseDetailView> {
               // Rating summary bar
               // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
               // to avoid allocating a closure on every widget rebuild
-              var sum = 0.0;
-              for (final r in reviews) {
-                sum += r.rating;
+              if (!identical(reviews, _cachedReviews)) {
+                var sum = 0.0;
+                for (final r in reviews) {
+                  sum += r.rating;
+                }
+                _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+                _cachedReviews = reviews;
               }
-              final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              final avg = _cachedAvg;
 
               return Column(
                 children: [

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -90,26 +90,24 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       // Optimization: Skip O(N) list traversal and object allocation when there are no active filters
-      _filteredVideos =
-          isQueryEmpty
-              ? _allVideos
-              : _allVideos.where((v) {
-                  return searchRegex!.hasMatch(v.title) ||
-                      searchRegex.hasMatch(v.description);
-                }).toList();
+      _filteredVideos = isQueryEmpty
+          ? _allVideos
+          : _allVideos.where((v) {
+              return searchRegex!.hasMatch(v.title) ||
+                  searchRegex.hasMatch(v.description);
+            }).toList();
 
-      _filteredCourses =
-          (isQueryEmpty && isCategoryAll)
-              ? _allCourses
-              : _allCourses.where((c) {
-                  final matchesSearch =
-                      isQueryEmpty ||
-                      searchRegex!.hasMatch(c.title) ||
-                      searchRegex.hasMatch(c.description);
-                  final matchesCategory =
-                      isCategoryAll || c.category == _selectedCategory;
-                  return matchesSearch && matchesCategory;
-                }).toList();
+      _filteredCourses = (isQueryEmpty && isCategoryAll)
+          ? _allCourses
+          : _allCourses.where((c) {
+              final matchesSearch =
+                  isQueryEmpty ||
+                  searchRegex!.hasMatch(c.title) ||
+                  searchRegex.hasMatch(c.description);
+              final matchesCategory =
+                  isCategoryAll || c.category == _selectedCategory;
+              return matchesSearch && matchesCategory;
+            }).toList();
     });
   }
 

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -25,6 +25,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
     contentCollection: 'videos',
   );
   late Stream<List<Review>> _reviewsStream;
+  List<Review>? _cachedReviews;
+  double _cachedAvg = 0.0;
 
   @override
   void initState() {
@@ -350,11 +352,15 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
 
             // ⚡ Bolt: Use a standard for loop to compute the average instead of .fold
             // to avoid allocating a closure on every widget rebuild
-            var sum = 0.0;
-            for (final r in reviews) {
-              sum += r.rating;
+            if (!identical(reviews, _cachedReviews)) {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
             }
-            final avg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+            final avg = _cachedAvg;
 
             return Column(
               children: [


### PR DESCRIPTION
💡 **What:** Memoized the average rating calculations within the `StreamBuilder` widgets in `CourseDetailView` and `VideoPlayerView`.

🎯 **Why:** Previously, the O(N) calculation to determine the average rating ran every time the `build` method executed, even if the underlying `Stream` data had not changed (for example, when a state variable like `_isEnrolling` updated or an animation occurred). This wasted CPU cycles. By caching the calculation and using Dart's fast O(1) `identical()` check against the list reference, the calculation is skipped unless the list instance actually changes.

📊 **Impact:** Prevents redundant O(N) list traversals inside the `StreamBuilder` rendering paths on widget rebuilds, reducing unnecessary CPU overhead.

🔬 **Measurement:** This optimization can be verified by observing CPU usage and widget build times in the Flutter DevTools performance tab during parent widget rebuilds (e.g., toggling UI state or scrolling).

✅ **Verification:** 
- `dart format` run
- `dart analyze` passes with no new issues
- `flutter test` suite fully passes

---
*PR created automatically by Jules for task [5126373355903237191](https://jules.google.com/task/5126373355903237191) started by @manupawickramasinghe*