### PR TITLE
🎨 Palette: [UX improvement] Add semantic labels to overlay InkWells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-12 - Add tooltip to icon-only back buttons
 **Learning:** In Flutter, ensure icon-only buttons (like `IconButton`) always have a descriptive `tooltip` attribute added. This provides proper accessibility labels for screen readers and helpful context for mouse hover states.
 **Action:** Always include a `tooltip` string on `IconButton` widgets, especially when they act as standalone navigational elements.
+
+## 2024-06-03 - Semantic labels for overlay InkWells
+**Learning:** When building custom clickable cards using a Stack where an InkWell overlay is separated from the visual content via Positioned.fill, screen readers will announce a generic or empty button because the InkWell has no semantic children.
+**Action:** Wrap the overlay InkWell in a Semantics widget with a specific, descriptive label (e.g., label: 'Course: ${course.title}') to ensure screen readers announce the specific item content.

--- a/lib/core/glass_widgets.dart
+++ b/lib/core/glass_widgets.dart
@@ -340,9 +340,8 @@ class _NavItem extends StatelessWidget {
                 children: [
                   Icon(
                     icon,
-                    color: isSelected
-                        ? AppTheme.primaryColor
-                        : AppTheme.textMuted,
+                    color:
+                        isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
                     size: 24,
                   ),
                   const SizedBox(height: 4),
@@ -350,9 +349,8 @@ class _NavItem extends StatelessWidget {
                     label,
                     style: TextStyle(
                       fontSize: 11,
-                      fontWeight: isSelected
-                          ? FontWeight.w600
-                          : FontWeight.w500,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.w500,
                       color: isSelected
                           ? AppTheme.primaryColor
                           : AppTheme.textMuted,

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -31,8 +31,7 @@ class Course {
       rating: (data?['rating'] ?? 0.0).toDouble(),
       category: data?['category'] ?? 'General',
       studentCount: data?['studentCount'] ?? 0,
-      lessons:
-          (data?['lessons'] as List<dynamic>?)
+      lessons: (data?['lessons'] as List<dynamic>?)
               ?.map(
                 (lessonData) =>
                     Lesson.fromJson(lessonData as Map<String, dynamic>),

--- a/lib/services/course_service.dart
+++ b/lib/services/course_service.dart
@@ -6,7 +6,7 @@ class CourseService {
   final FirebaseFirestore _db;
 
   CourseService({FirebaseFirestore? db})
-    : _db = db ?? FirebaseFirestore.instance;
+      : _db = db ?? FirebaseFirestore.instance;
 
   // Optimization: Added optional limit parameter to prevent unbounded reads
   Future<List<Course>> getRecommendedCourses({int? limit}) async {

--- a/lib/services/video_service.dart
+++ b/lib/services/video_service.dart
@@ -6,7 +6,7 @@ class VideoService {
   final FirebaseFirestore _db;
 
   VideoService({FirebaseFirestore? db})
-    : _db = db ?? FirebaseFirestore.instance;
+      : _db = db ?? FirebaseFirestore.instance;
 
   // Optimization: Added optional limit parameter to prevent unbounded reads
   Future<List<Video>> getVideos({int? limit}) async {

--- a/lib/viewmodels/auth_viewmodel.dart
+++ b/lib/viewmodels/auth_viewmodel.dart
@@ -126,8 +126,8 @@ class AuthViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final GoogleSignInAccount? googleUser = await GoogleSignIn.instance
-          .authenticate();
+      final GoogleSignInAccount? googleUser =
+          await GoogleSignIn.instance.authenticate();
       if (googleUser == null) {
         _isLoading = false;
         notifyListeners();

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -31,10 +31,10 @@ class _LoginViewState extends State<LoginView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
-        .animate(
-          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-        );
+    _slideAnim =
+        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
+      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+    );
     _animController.forward();
   }
 

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -30,10 +30,10 @@ class _SignupViewState extends State<SignupView>
       duration: const Duration(milliseconds: 900),
     );
     _fadeAnim = CurvedAnimation(parent: _animController, curve: Curves.easeOut);
-    _slideAnim = Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero)
-        .animate(
-          CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
-        );
+    _slideAnim =
+        Tween<Offset>(begin: const Offset(0, 0.06), end: Offset.zero).animate(
+      CurvedAnimation(parent: _animController, curve: Curves.easeOutCubic),
+    );
     _animController.forward();
   }
 

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -57,9 +57,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
   }
 
   Widget _buildAppBar(BuildContext context) {
-    final colors =
-        AppTheme.cardGradients[widget.course.title.length %
-            AppTheme.cardGradients.length];
+    final colors = AppTheme.cardGradients[
+        widget.course.title.length % AppTheme.cardGradients.length];
 
     return SliverAppBar(
       expandedHeight: 260,
@@ -428,8 +427,9 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                                               i < avg.floor()
                                                   ? Icons.star_rounded
                                                   : i < avg
-                                                  ? Icons.star_half_rounded
-                                                  : Icons.star_border_rounded,
+                                                      ? Icons.star_half_rounded
+                                                      : Icons
+                                                          .star_border_rounded,
                                               color: Colors.amber,
                                               size: 20,
                                             ),

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -818,8 +818,8 @@ class _ReviewsViewState extends State<ReviewsView> {
               i < rating.floor()
                   ? Icons.star_rounded
                   : i < rating
-                  ? Icons.star_half_rounded
-                  : Icons.star_border_rounded,
+                      ? Icons.star_half_rounded
+                      : Icons.star_border_rounded,
               color: Colors.amber,
               size: size,
             ),

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -90,26 +90,23 @@ class _ExploreViewState extends State<ExploreView> {
 
     setState(() {
       // Optimization: Skip O(N) list traversal and object allocation when there are no active filters
-      _filteredVideos =
-          isQueryEmpty
-              ? _allVideos
-              : _allVideos.where((v) {
-                  return searchRegex!.hasMatch(v.title) ||
-                      searchRegex.hasMatch(v.description);
-                }).toList();
+      _filteredVideos = isQueryEmpty
+          ? _allVideos
+          : _allVideos.where((v) {
+              return searchRegex!.hasMatch(v.title) ||
+                  searchRegex.hasMatch(v.description);
+            }).toList();
 
-      _filteredCourses =
-          (isQueryEmpty && isCategoryAll)
-              ? _allCourses
-              : _allCourses.where((c) {
-                  final matchesSearch =
-                      isQueryEmpty ||
-                      searchRegex!.hasMatch(c.title) ||
-                      searchRegex.hasMatch(c.description);
-                  final matchesCategory =
-                      isCategoryAll || c.category == _selectedCategory;
-                  return matchesSearch && matchesCategory;
-                }).toList();
+      _filteredCourses = (isQueryEmpty && isCategoryAll)
+          ? _allCourses
+          : _allCourses.where((c) {
+              final matchesSearch = isQueryEmpty ||
+                  searchRegex!.hasMatch(c.title) ||
+                  searchRegex.hasMatch(c.description);
+              final matchesCategory =
+                  isCategoryAll || c.category == _selectedCategory;
+              return matchesSearch && matchesCategory;
+            }).toList();
     });
   }
 
@@ -192,9 +189,8 @@ class _ExploreViewState extends State<ExploreView> {
                           child: AnimatedContainer(
                             duration: const Duration(milliseconds: 200),
                             decoration: BoxDecoration(
-                              gradient: isSelected
-                                  ? AppTheme.primaryGradient
-                                  : null,
+                              gradient:
+                                  isSelected ? AppTheme.primaryGradient : null,
                               color: isSelected
                                   ? null
                                   : Colors.white.withValues(alpha: 0.08),
@@ -426,12 +422,15 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -505,12 +504,15 @@ class _ExploreViewState extends State<ExploreView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -456,12 +456,15 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(20),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => CourseDetailView(course: course),
+                child: Semantics(
+                  label: 'Course: ${course.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(20),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CourseDetailView(course: course),
+                      ),
                     ),
                   ),
                 ),
@@ -558,12 +561,15 @@ class _HomeViewState extends State<HomeView> {
             Positioned.fill(
               child: Material(
                 color: Colors.transparent,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(16),
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => VideoPlayerView(video: video),
+                child: Semantics(
+                  label: 'Video: ${video.title}',
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(16),
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VideoPlayerView(video: video),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/views/profile/profile_view.dart
+++ b/lib/views/profile/profile_view.dart
@@ -252,14 +252,14 @@ class ProfileView extends StatelessWidget {
                           borderRadius: index == 0 && items.length == 1
                               ? BorderRadius.circular(16)
                               : index == 0
-                              ? const BorderRadius.vertical(
-                                  top: Radius.circular(16),
-                                )
-                              : index == items.length - 1
-                              ? const BorderRadius.vertical(
-                                  bottom: Radius.circular(16),
-                                )
-                              : BorderRadius.zero,
+                                  ? const BorderRadius.vertical(
+                                      top: Radius.circular(16),
+                                    )
+                                  : index == items.length - 1
+                                      ? const BorderRadius.vertical(
+                                          bottom: Radius.circular(16),
+                                        )
+                                      : BorderRadius.zero,
                           onTap: items[index].onTap,
                           child: Padding(
                             padding: const EdgeInsets.symmetric(

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -407,8 +407,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                                             i < avg.floor()
                                                 ? Icons.star_rounded
                                                 : i < avg
-                                                ? Icons.star_half_rounded
-                                                : Icons.star_border_rounded,
+                                                    ? Icons.star_half_rounded
+                                                    : Icons.star_border_rounded,
                                             color: Colors.amber,
                                             size: 20,
                                           ),


### PR DESCRIPTION
💡 What: Added `Semantics` widgets with specific labels (e.g., 'Course: [Title]', 'Video: [Title]') to the `InkWell` overlays inside custom cards in `home_view.dart` and `explore_view.dart`.

🎯 Why: Custom clickable cards built with a `Stack` often separate the visual content from the tappable area (`Positioned.fill` with `InkWell`). Screen readers would announce these tappable overlays as empty or generic buttons because the `InkWell` had no semantic children or labels, making it impossible for visually impaired users to know what they were clicking on.

📸 Before/After: Visuals remain entirely unchanged.

♿ Accessibility: Screen readers (TalkBack/VoiceOver) will now correctly announce the specific title of the course or video when focusing on the card's tap area.

---
*PR created automatically by Jules for task [4941101136511305516](https://jules.google.com/task/4941101136511305516) started by @manupawickramasinghe*