### PR TITLE
⚡ Bolt: Memoize _sorted method in ReviewsView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## YYYY-MM-DD - Flutter StreamBuilder Memoization
 **Learning:** In Flutter, `StreamBuilder` can rebuild multiple times with the same data instance (e.g., due to parent widget rebuilds or unrelated state changes). Running expensive O(N) operations (like computing averages or mapping data) directly inside the `build` method for every rebuild causes unnecessary CPU usage and stutter.
 **Action:** Always memoize expensive O(N) operations inside `build` methods (especially inside `StreamBuilder`) by caching the list reference and the result as state variables. Use Dart's `identical(newList, _cachedList)` for an O(1) identity check to quickly skip recalculations when the stream data instance hasn't changed.
+## 2026-06-06 - Memoize Sorting in Build Methods
+**Learning:** Sorting operations (O(N log N)) directly inside `build` methods or `StreamBuilder` callbacks without memoization cause heavy recalculations on every rebuild.
+**Action:** Use `identical()` reference checks to cache sorted lists and skip recalculations when the incoming stream data instance hasn't changed.

--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -39,6 +39,10 @@ class _ReviewsViewState extends State<ReviewsView> {
   double _cachedAvg = 0.0;
   Map<int, int> _cachedCounts = {5: 0, 4: 0, 3: 0, 2: 0, 1: 0};
 
+  List<Review>? _cachedSortedReviews;
+  List<Review>? _lastUnsortedReviews;
+  _SortBy? _lastSortBy;
+
   @override
   void initState() {
     super.initState();
@@ -82,8 +86,22 @@ class _ReviewsViewState extends State<ReviewsView> {
       // ⚡ Bolt: Prevent O(N) list allocation and copying when the default sort (Newest First) is already applied by the Firestore query.
       return reviews;
     }
+
+    // ⚡ Bolt: Memoize the O(N log N) sort operation to prevent re-sorting on every widget rebuild
+    // by using an O(1) identity check on the stream data instance.
+    if (identical(reviews, _lastUnsortedReviews) &&
+        _sortBy == _lastSortBy &&
+        _cachedSortedReviews != null) {
+      return _cachedSortedReviews!;
+    }
+
     final list = List<Review>.from(reviews);
     list.sort((a, b) => b.rating.compareTo(a.rating));
+
+    _lastUnsortedReviews = reviews;
+    _lastSortBy = _sortBy;
+    _cachedSortedReviews = list;
+
     return list;
   }
 


### PR DESCRIPTION
💡 **What:** Added an identity cache (`identical`) for the `_sorted` function inside `ReviewsView`'s state. 
🎯 **Why:** Previously, when `_sortBy` was set to `_SortBy.topRated`, the sorting logic created a new list (`List.from`) and sorted it (`O(N log N)`) directly within the `StreamBuilder`'s `build` callback on every single widget rebuild (even for unrelated UI interactions or animations). This blocks the main UI thread unnecessarily.
📊 **Impact:** Reduces CPU load and O(N) memory allocation to an `O(1)` identity check whenever the incoming `Stream` emits the exact same data instance.
🔬 **Measurement:** Verified via logic inspection that sorting only executes if the active sort option changes or if the underlying stream provides a completely new `List` object. Unit tests confirm no regressions.

---
*PR created automatically by Jules for task [1886992074873688398](https://jules.google.com/task/1886992074873688398) started by @manupawickramasinghe*