### PR TITLE
🎨 Palette: Add tooltip to sort reviews menu

### DIFF
--- a/lib/views/course/reviews_view.dart
+++ b/lib/views/course/reviews_view.dart
@@ -200,6 +200,7 @@ class _ReviewsViewState extends State<ReviewsView> {
         ),
         actions: [
           PopupMenuButton<_SortBy>(
+            tooltip: 'Sort reviews',
             initialValue: _sortBy,
             onSelected: (v) => setState(() => _sortBy = v),
             color: AppTheme.surfaceColor,


### PR DESCRIPTION
💡 What: Added a descriptive `tooltip` ('Sort reviews') to the `PopupMenuButton` in `lib/views/course/reviews_view.dart`.

🎯 Why: To improve usability and accessibility. Previously, the button only had the default "Show menu" tooltip, which lacked context. The new tooltip provides clear guidance to mouse users on hover and explicitly labels the interactive element for screen readers.

📸 Before/After: Not applicable (tooltip only).

♿ Accessibility: Provides an explicit, descriptive accessible name for the sort button, ensuring assistive technologies correctly announce its purpose.

---
*PR created automatically by Jules for task [18162863729638718753](https://jules.google.com/task/18162863729638718753) started by @manupawickramasinghe*