### PR TITLE
🎨 Palette: [UX improvement] Add explicit focus and hover states to custom interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 ## 2024-05-30 - Interactive Components Tap Feedback Regression Fix
 **Learning:** In Flutter, when moving a tap action from an outer `GestureDetector` to an inner `InkWell` to provide localized ripple feedback on a specific child element (like a card within a Column), sibling elements (like trailing text or inline elements) can inadvertently lose clickability.
 **Action:** To maintain a large interactive area (including empty spaces) while providing specific visual feedback on a child, wrap the entire parent container in a `GestureDetector` with `behavior: HitTestBehavior.opaque` to catch taps outside the specific `InkWell` area.
+## 2026-06-13 - [Visible Focus States for Custom InkWells]
+**Learning:** In Flutter, when building custom interactive components (like glassmorphic UI elements) using `InkWell` on top of transparent or heavily styled backgrounds, the default focus and hover indicators may become invisible or blend in too much, leading to poor keyboard and mouse accessibility.
+**Action:** Always explicitly define `focusColor` and `hoverColor` on `InkWell` widgets within custom interactive components to ensure clear visual feedback for non-touch device users.

--- a/lib/core/glass_widgets.dart
+++ b/lib/core/glass_widgets.dart
@@ -84,6 +84,8 @@ class GlassButton extends StatelessWidget {
           child: InkWell(
             onTap: isDisabled ? null : onPressed,
             borderRadius: BorderRadius.circular(borderRadius),
+            focusColor: Colors.white.withValues(alpha: 0.2),
+            hoverColor: Colors.white.withValues(alpha: 0.1),
             child: Padding(
               padding: padding,
               child: Center(
@@ -332,6 +334,8 @@ class _NavItem extends StatelessWidget {
           child: InkWell(
             borderRadius: BorderRadius.circular(12),
             onTap: onTap,
+            focusColor: AppTheme.primaryColor.withValues(alpha: 0.2),
+            hoverColor: AppTheme.primaryColor.withValues(alpha: 0.1),
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Column(
@@ -339,8 +343,9 @@ class _NavItem extends StatelessWidget {
                 children: [
                   Icon(
                     icon,
-                    color:
-                        isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
+                    color: isSelected
+                        ? AppTheme.primaryColor
+                        : AppTheme.textMuted,
                     size: 24,
                   ),
                   const SizedBox(height: 4),
@@ -348,8 +353,9 @@ class _NavItem extends StatelessWidget {
                     label,
                     style: TextStyle(
                       fontSize: 11,
-                      fontWeight:
-                          isSelected ? FontWeight.w600 : FontWeight.w500,
+                      fontWeight: isSelected
+                          ? FontWeight.w600
+                          : FontWeight.w500,
                       color: isSelected
                           ? AppTheme.primaryColor
                           : AppTheme.textMuted,


### PR DESCRIPTION
💡 What: Added explicit `focusColor` and `hoverColor` properties to the `InkWell` widgets within `GlassButton` and `_NavItem`.
🎯 Why: In custom glassmorphic components, default focus and hover indicators often blend into the background, making it difficult for keyboard and mouse users to see which element is currently targeted. This improves visual feedback.
📸 Before/After: Interactive elements now display a semi-transparent white or primary color overlay when focused via keyboard (Tab) or hovered via mouse.
♿ Accessibility: Improved keyboard navigation accessibility by providing clear visual focus indicators on all custom buttons and bottom navigation tabs.

---
*PR created automatically by Jules for task [6527528137315985472](https://jules.google.com/task/6527528137315985472) started by @manupawickramasinghe*