### PR TITLE
⚡ Bolt: optimize firestore mapping with collection for loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -60,3 +60,6 @@
 ## 2024-06-10 - Flutter .fold() and .take() Rebuild Overhead
 **Learning:** In Flutter, higher-order functions like .fold() and .take() create closures and intermediate iterable objects (like TakeIterable) on every widget rebuild, increasing garbage collection pressure. Furthermore, calculating an average using .fold() on every frame is an O(N) operation that should be avoided if the underlying list hasn't changed.
 **Action:** Replace .fold() with explicit loops and cache the result using identical() checks on the list reference. Replace .take() with explicit index-based collection for loops to avoid object allocation during rendering.
+## 2026-06-13 - Replace .map().toList() with Collection For Loops
+**Learning:** In Dart, chaining `.map().toList()` creates an intermediate `MappedIterable` and its associated closure object before immediately consuming it into a list. For Firestore query snapshots, this allocates unnecessary objects on the heap.
+**Action:** Use a Dart collection `for` loop (e.g., `[for (final doc in snapshot.docs) Model.fromFirestore(doc)]`) to construct the list directly without intermediate iterables, reducing garbage collection pressure.

--- a/lib/services/course_service.dart
+++ b/lib/services/course_service.dart
@@ -16,7 +16,11 @@ class CourseService {
         query = query.limit(limit);
       }
       final snapshot = await query.get();
-      return snapshot.docs.map((doc) => Course.fromFirestore(doc)).toList();
+      // ⚡ Bolt: Use collection for loop to directly construct list
+      // avoiding intermediate Iterable allocation from .map().toList()
+      return [
+        for (final doc in snapshot.docs) Course.fromFirestore(doc),
+      ];
     } catch (e) {
       debugPrint('Error fetching courses: $e');
       return [];

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -23,7 +23,13 @@ class ReviewService {
     return _reviewsRef(contentId)
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map((s) => s.docs.map((doc) => Review.fromFirestore(doc)).toList());
+        .map((s) {
+      // ⚡ Bolt: Use collection for loop to directly construct list
+      // avoiding intermediate Iterable allocation from .map().toList()
+      return [
+        for (final doc in s.docs) Review.fromFirestore(doc),
+      ];
+    });
   }
 
   /// Returns the current user's review, or null if they haven't reviewed yet.

--- a/lib/services/video_service.dart
+++ b/lib/services/video_service.dart
@@ -16,7 +16,11 @@ class VideoService {
         query = query.limit(limit);
       }
       final snapshot = await query.get();
-      return snapshot.docs.map((doc) => Video.fromFirestore(doc)).toList();
+      // ⚡ Bolt: Use collection for loop to directly construct list
+      // avoiding intermediate Iterable allocation from .map().toList()
+      return [
+        for (final doc in snapshot.docs) Video.fromFirestore(doc),
+      ];
     } catch (e) {
       debugPrint('Error fetching videos: $e');
       return [];


### PR DESCRIPTION
**💡 What:**
Replaced the `.map((doc) => Model.fromFirestore(doc)).toList()` pattern with Dart's collection `for` loop `[for (final doc in snapshot.docs) Model.fromFirestore(doc)]` inside `CourseService`, `VideoService`, and `ReviewService`. 

**🎯 Why:**
Chaining `.map().toList()` in Dart creates a lazy intermediate `MappedIterable` wrapper and allocates a new closure object before immediately consuming it into a `List`. For Firestore query snapshots where the size is known, using a collection `for` loop constructs the list directly in place, preventing unnecessary heap allocations and reducing garbage collection pressure, making the data parsing layer slightly more efficient.

**📊 Impact:**
Reduces object allocation count per Firestore read operation. While a micro-optimization on its own, applying this pattern globally across all service data mappers prevents compounding memory overhead as lists grow larger or are queried more frequently.

**🔬 Measurement:**
Tested via `flutter test` to ensure functional parsing logic remains exactly the same. Verified that dart analyzer passes cleanly on the modified service files without introducing type mismatches.

---
*PR created automatically by Jules for task [10533903300043465109](https://jules.google.com/task/10533903300043465109) started by @manupawickramasinghe*