### PR TITLE
⚡ Bolt: Replace `.where().toList()` with collection `for-if` loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -63,3 +63,7 @@
 ## 2026-06-13 - Replace .map().toList() with Collection For Loops
 **Learning:** In Dart, chaining `.map().toList()` creates an intermediate `MappedIterable` and its associated closure object before immediately consuming it into a list. For Firestore query snapshots, this allocates unnecessary objects on the heap.
 **Action:** Use a Dart collection `for` loop (e.g., `[for (final doc in snapshot.docs) Model.fromFirestore(doc)]`) to construct the list directly without intermediate iterables, reducing garbage collection pressure.
+
+## 2026-06-15 - Replace .where().toList() with Collection For-If Loops
+**Learning:** In Dart, filtering a list using `.where(condition).toList()` creates an intermediate `WhereIterable` and closure object before consuming it into a list, creating unnecessary garbage collection overhead.
+**Action:** Use a Dart collection `for` loop with an `if` condition (e.g., `[for (final item in list) if (condition) item]`) to construct the filtered list directly without intermediate iterables, reducing garbage collection pressure.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -92,21 +92,27 @@ class _ExploreViewState extends State<ExploreView> {
       // Optimization: Skip O(N) list traversal and object allocation when there are no active filters
       _filteredVideos = isQueryEmpty
           ? _allVideos
-          : _allVideos.where((v) {
-              return searchRegex!.hasMatch(v.title) ||
-                  searchRegex.hasMatch(v.description);
-            }).toList();
+          // ⚡ Bolt: Use collection for-if loop to directly construct list
+          // avoiding intermediate WhereIterable allocation from .where().toList()
+          : [
+              for (final v in _allVideos)
+                if (searchRegex!.hasMatch(v.title) ||
+                    searchRegex.hasMatch(v.description))
+                  v,
+            ];
 
       _filteredCourses = (isQueryEmpty && isCategoryAll)
           ? _allCourses
-          : _allCourses.where((c) {
-              final matchesSearch = isQueryEmpty ||
-                  searchRegex!.hasMatch(c.title) ||
-                  searchRegex.hasMatch(c.description);
-              final matchesCategory =
-                  isCategoryAll || c.category == _selectedCategory;
-              return matchesSearch && matchesCategory;
-            }).toList();
+          // ⚡ Bolt: Use collection for-if loop to directly construct list
+          // avoiding intermediate WhereIterable allocation from .where().toList()
+          : [
+              for (final c in _allCourses)
+                if ((isQueryEmpty ||
+                        searchRegex!.hasMatch(c.title) ||
+                        searchRegex.hasMatch(c.description)) &&
+                    (isCategoryAll || c.category == _selectedCategory))
+                  c,
+            ];
     });
   }
 
@@ -189,8 +195,9 @@ class _ExploreViewState extends State<ExploreView> {
                           child: AnimatedContainer(
                             duration: const Duration(milliseconds: 200),
                             decoration: BoxDecoration(
-                              gradient:
-                                  isSelected ? AppTheme.primaryGradient : null,
+                              gradient: isSelected
+                                  ? AppTheme.primaryGradient
+                                  : null,
                               color: isSelected
                                   ? null
                                   : Colors.white.withValues(alpha: 0.08),


### PR DESCRIPTION
💡 What: Replaced `.where().toList()` with collection `for-if` loop in `ExploreView._filterContent`.
🎯 Why: To avoid intermediate `WhereIterable` allocations during interactive search filtering, reducing garbage collection pressure.
✅ Verification: Ran `flutter test` and `flutter analyze` to ensure the logic remains intact.
✨ Result: Faster interactive filtering and less garbage collection overhead.
📊 Impact: Eliminates `WhereIterable` and closure allocations on each keystroke when filtering lists.
🔬 Measurement: Observe heap allocation and dropped frames during rapid search filtering.

---
*PR created automatically by Jules for task [6307735368253783891](https://jules.google.com/task/6307735368253783891) started by @manupawickramasinghe*