### PR TITLE
⚡ Bolt: Optimize .toList() allocations to reduce GC overhead

### DIFF
--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -31,13 +31,14 @@ class Course {
       rating: (data?['rating'] ?? 0.0).toDouble(),
       category: data?['category'] ?? 'General',
       studentCount: data?['studentCount'] ?? 0,
-      lessons: (data?['lessons'] as List<dynamic>?)
-              ?.map(
-                (lessonData) =>
-                    Lesson.fromJson(lessonData as Map<String, dynamic>),
-              )
-              .toList() ??
-          [],
+      lessons: (data?['lessons'] as List<dynamic>?) != null
+          ? [
+              // ⚡ Bolt: Use collection for loop to directly construct list
+              // avoiding intermediate Iterable allocation from .map().toList()
+              for (final lessonData in (data!['lessons'] as List<dynamic>))
+                Lesson.fromJson(lessonData as Map<String, dynamic>),
+            ]
+          : [],
     );
   }
 }

--- a/lib/studies/lms/data_service.dart
+++ b/lib/studies/lms/data_service.dart
@@ -68,7 +68,11 @@ class LmsDataService {
 
     if (response.statusCode == 200) {
       final List<dynamic> videoJson = json.decode(response.body);
-      return videoJson.map((json) => Video.fromJson(json)).toList();
+      // ⚡ Bolt: Use collection for loop to directly construct list
+      // avoiding intermediate Iterable allocation from .map().toList()
+      return [
+        for (final json in videoJson) Video.fromJson(json),
+      ];
     } else {
       throw Exception(
         'Failed to load videos. Status code: ${response.statusCode}',

--- a/lib/studies/shrine/model/products_repository.dart
+++ b/lib/studies/shrine/model/products_repository.dart
@@ -314,7 +314,12 @@ class ProductsRepository {
     if (category == categoryAll) {
       return allProducts;
     } else {
-      return allProducts.where((p) => p.category == category).toList();
+      // ⚡ Bolt: Use collection for-if loop to directly construct list
+      // avoiding intermediate WhereIterable allocation from .where().toList()
+      return [
+        for (final p in allProducts)
+          if (p.category == category) p,
+      ];
     }
   }
 }


### PR DESCRIPTION
### 💡 What
Replaced `.map().toList()` and `.where().toList()` chains with Dart collection `for` and `for-if` loops in `Course.fromFirestore`, `LmsDataService.fetchVideos`, and `ProductsRepository.loadProducts`.

### 🎯 Why
In Dart, chaining methods like `.map().toList()` or `.where().toList()` allocates intermediate lazy `Iterable` objects (`MappedIterable`, `WhereIterable`) and their associated closure contexts. These intermediate objects exist only briefly before being immediately consumed by `.toList()`, generating unnecessary garbage collection pressure and CPU overhead on every invocation.

### 📊 Impact
Reduces object allocations and heap memory churn during model deserialization and list filtering, leading to faster list generation and reduced garbage collection pauses.

### 🔬 Measurement
Run `flutter test` to verify that functionality is preserved. Benchmark JSON parsing and list generation to observe fewer intermediate allocations.

---
*PR created automatically by Jules for task [43195200740983147](https://jules.google.com/task/43195200740983147) started by @manupawickramasinghe*