### PR TITLE
🎨 Palette: [UX improvement] Explicit Hover/Focus Colors for Custom Backgrounds

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-06-06 - Remove redundant Semantics(button: true) wrappers around InkWell
 **Learning:** In Flutter, `InkWell` inherently provides button semantics to the accessibility tree when it has an interaction callback like `onTap`. Manually wrapping an `InkWell` with `Semantics(button: true)` causes screen readers (like TalkBack or VoiceOver) to redundantly announce the element as a "button" multiple times. However, if the wrapping `Semantics` widget uses `excludeSemantics: true`, the `InkWell`'s implicit traits are dropped, and `button: true` MUST be explicitly re-declared.
 **Action:** Audit and remove redundant `Semantics(button: true)` wrappers around `InkWell` widgets to clean up the semantic tree, except where `excludeSemantics: true` is used or when explicitly required on a parent structural widget.
+
+## 2026-06-19 - Explicit Hover and Focus Colors on Custom Backgrounds
+**Learning:** In Flutter, `InkWell` widgets placed over custom backgrounds (like glassmorphism) often lose their default hover and focus indicator visibility due to low contrast, impairing keyboard navigation accessibility.
+**Action:** Always explicitly define `focusColor` and `hoverColor` on `InkWell` elements to ensure focus indicators and mouse hover states remain visible and accessible.

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -216,6 +216,8 @@ class _ExploreViewState extends State<ExploreView> {
                                 selected: isSelected,
                                 child: InkWell(
                                   borderRadius: BorderRadius.circular(20),
+                                  focusColor: Colors.white.withValues(alpha: 0.2),
+                                  hoverColor: Colors.white.withValues(alpha: 0.1),
                                   onTap: () {
                                     setState(
                                       () => _selectedCategory = category,
@@ -433,6 +435,8 @@ class _ExploreViewState extends State<ExploreView> {
                   label: 'Course: ${course.title}',
                   child: InkWell(
                     borderRadius: BorderRadius.circular(16),
+                    focusColor: Colors.white.withValues(alpha: 0.2),
+                    hoverColor: Colors.white.withValues(alpha: 0.1),
                     onTap: () => Navigator.push(
                       context,
                       MaterialPageRoute(
@@ -516,6 +520,8 @@ class _ExploreViewState extends State<ExploreView> {
                   label: 'Video: ${video.title}',
                   child: InkWell(
                     borderRadius: BorderRadius.circular(16),
+                    focusColor: Colors.white.withValues(alpha: 0.2),
+                    hoverColor: Colors.white.withValues(alpha: 0.1),
                     onTap: () => Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -157,6 +157,8 @@ class _HomeViewState extends State<HomeView> {
                 color: Colors.transparent,
                 child: InkWell(
                   borderRadius: BorderRadius.circular(16),
+                  focusColor: Colors.white.withValues(alpha: 0.2),
+                  hoverColor: Colors.white.withValues(alpha: 0.1),
                   onTap: () {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
@@ -212,6 +214,8 @@ class _HomeViewState extends State<HomeView> {
           excludeSemantics: true,
           child: InkWell(
             borderRadius: BorderRadius.circular(16),
+            focusColor: Colors.white.withValues(alpha: 0.2),
+            hoverColor: Colors.white.withValues(alpha: 0.1),
             onTap: widget.onSearchTap,
             child: const Padding(
               padding: EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -464,6 +468,8 @@ class _HomeViewState extends State<HomeView> {
                   label: 'Course: ${course.title}',
                   child: InkWell(
                     borderRadius: BorderRadius.circular(20),
+                    focusColor: Colors.white.withValues(alpha: 0.2),
+                    hoverColor: Colors.white.withValues(alpha: 0.1),
                     onTap: () => Navigator.push(
                       context,
                       MaterialPageRoute(
@@ -570,6 +576,8 @@ class _HomeViewState extends State<HomeView> {
                   label: 'Video: ${video.title}',
                   child: InkWell(
                     borderRadius: BorderRadius.circular(16),
+                    focusColor: Colors.white.withValues(alpha: 0.2),
+                    hoverColor: Colors.white.withValues(alpha: 0.1),
                     onTap: () => Navigator.push(
                       context,
                       MaterialPageRoute(


### PR DESCRIPTION
💡 **What:** Added explicit `focusColor` and `hoverColor` attributes to `InkWell` widgets on the Home and Explore views. Also updated the `.jules/palette.md` journal with a critical learning about custom background contrast.

🎯 **Why:** In Flutter, `InkWell` widgets placed over custom backgrounds (like glassmorphism) often lose their default hover and focus indicator visibility due to low contrast. Adding explicit colors ensures keyboard navigation and mouse hover states remain visible and accessible.

📸 **Before/After:**
*(Visual changes improve contrast during hover/focus on cards and interactive elements)*

♿ **Accessibility:**
- Improves keyboard navigation by ensuring focus states are visibly distinguishable against custom gradients and blurred backgrounds.
- Enhances mouse interaction feedback with clear hover states for interactive components.

---
*PR created automatically by Jules for task [4363105843967445955](https://jules.google.com/task/4363105843967445955) started by @manupawickramasinghe*