### PR TITLE
⚡ Bolt: Replace .fold() with explicit loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -71,3 +71,6 @@
 ## 2024-06-20 - Replace .where().toList() and .map().toList() with Collection For Loops
 **Learning:** In Dart, using `.where(condition).toList()` or `.map(fn).toList()` creates an intermediate `WhereIterable` or `MappedIterable` along with their associated closure objects, before immediately iterating over them to create a list. This causes unnecessary intermediate allocations and increases garbage collection overhead, particularly when placed inside a rebuild path or used repeatedly on larger datasets.
 **Action:** Replace these patterns with Dart collection `for` and `if` loops (e.g., `[for (final item in list) if (condition) item]` or `[for (final item in list) fn(item)]`). This constructs the desired list directly without intermediate iterables, reducing garbage collection pressure.
+## 2024-06-25 - Avoid .fold() in Widget Build Methods
+**Learning:** In Flutter, higher-order functions like `.fold()` create closures and intermediate iterable objects on every widget rebuild, increasing garbage collection pressure. Furthermore, calculating an average using `.fold()` on every frame is an O(N) operation that should be avoided if the underlying list hasn't changed.
+**Action:** Replace `.fold()` with explicit loops and cache the result using `identical()` checks on the list reference to avoid object allocation during rendering.

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -354,8 +354,12 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            final avg =
-                reviews.fold(0.0, (s, r) => s + r.rating) / reviews.length;
+            // ⚡ Bolt: Replace .fold() with explicit loop to avoid closure and iterable allocation on every rebuild
+            var sum = 0.0;
+            for (final r in reviews) {
+              sum += r.rating;
+            }
+            final avg = sum / reviews.length;
 
             return GestureDetector(
               behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
💡 What: Replaced `.fold()` with an explicit `for` loop in `lib/views/video/video_player_view.dart`.
🎯 Why: `.fold()` creates closures and intermediate iterable objects on every widget rebuild, increasing garbage collection pressure.
📊 Impact: Reduces intermediate object allocations during the empty-review fallback UI build cycle.
🔬 Measurement: Observe memory footprint and rendering performance using Flutter DevTools when viewing a video without reviews.

---
*PR created automatically by Jules for task [833673689026383588](https://jules.google.com/task/833673689026383588) started by @manupawickramasinghe*