### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -304,6 +304,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(20),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -355,6 +357,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                         color: Colors.transparent,
                         child: InkWell(
                           borderRadius: BorderRadius.circular(16),
+                          focusColor: Colors.white.withValues(alpha: 0.2),
+                          hoverColor: Colors.white.withValues(alpha: 0.1),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -573,6 +577,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
           color: Colors.transparent,
           child: InkWell(
             borderRadius: BorderRadius.circular(14),
+            focusColor: Colors.white.withValues(alpha: 0.2),
+            hoverColor: Colors.white.withValues(alpha: 0.1),
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -300,6 +300,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(16),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -377,6 +379,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                       color: Colors.transparent,
                       child: InkWell(
                         borderRadius: BorderRadius.circular(16),
+                        focusColor: Colors.white.withValues(alpha: 0.2),
+                        hoverColor: Colors.white.withValues(alpha: 0.1),
                         onTap: () => Navigator.push(
                           context,
                           MaterialPageRoute(
@@ -461,6 +465,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(20),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(


### PR DESCRIPTION
💡 What: Added explicit `focusColor` and `hoverColor` to `InkWell` widgets within custom interactive cards (lesson items, review summaries).
🎯 Why: The default focus and hover indicators were blending into the background, leading to poor keyboard and mouse accessibility.
📸 Before/After: Visual focus and hover indicators are now clearly visible.
♿ Accessibility: Improved keyboard navigation visibility for non-touch device users.

---
*PR created automatically by Jules for task [3781599516787294040](https://jules.google.com/task/3781599516787294040) started by @manupawickramasinghe*