### PR TITLE
🎨 Palette: [UX improvement] Add focus/hover colors to custom InkWells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -23,3 +23,7 @@
 ## 2026-06-19 - Explicit Hover and Focus Colors on Custom Backgrounds
 **Learning:** In Flutter, `InkWell` widgets placed over custom backgrounds (like glassmorphism) often lose their default hover and focus indicator visibility due to low contrast, impairing keyboard navigation accessibility.
 **Action:** Always explicitly define `focusColor` and `hoverColor` on `InkWell` elements to ensure focus indicators and mouse hover states remain visible and accessible.
+
+## 2026-06-25 - Missing Focus/Hover colors on Custom InkWells
+**Learning:** In custom glassmorphic components, standard InkWells lack adequate focus and hover indicators because the custom background obscures standard framework defaults.
+**Action:** Always explicitly define `focusColor` and `hoverColor` on InkWell widgets within custom containers to ensure keyboard focus indicators and mouse hover states remain visible.

--- a/lib/core/glass_widgets.dart
+++ b/lib/core/glass_widgets.dart
@@ -343,9 +343,8 @@ class _NavItem extends StatelessWidget {
                 children: [
                   Icon(
                     icon,
-                    color: isSelected
-                        ? AppTheme.primaryColor
-                        : AppTheme.textMuted,
+                    color:
+                        isSelected ? AppTheme.primaryColor : AppTheme.textMuted,
                     size: 24,
                   ),
                   const SizedBox(height: 4),
@@ -353,9 +352,8 @@ class _NavItem extends StatelessWidget {
                     label,
                     style: TextStyle(
                       fontSize: 11,
-                      fontWeight: isSelected
-                          ? FontWeight.w600
-                          : FontWeight.w500,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.w500,
                       color: isSelected
                           ? AppTheme.primaryColor
                           : AppTheme.textMuted,

--- a/lib/views/course/course_detail_view.dart
+++ b/lib/views/course/course_detail_view.dart
@@ -304,6 +304,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(20),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -355,6 +357,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
                         color: Colors.transparent,
                         child: InkWell(
                           borderRadius: BorderRadius.circular(16),
+                          focusColor: Colors.white.withValues(alpha: 0.2),
+                          hoverColor: Colors.white.withValues(alpha: 0.1),
                           onTap: () => Navigator.push(
                             context,
                             MaterialPageRoute(
@@ -573,6 +577,8 @@ class _CourseDetailViewState extends State<CourseDetailView> {
           color: Colors.transparent,
           child: InkWell(
             borderRadius: BorderRadius.circular(14),
+            focusColor: Colors.white.withValues(alpha: 0.2),
+            hoverColor: Colors.white.withValues(alpha: 0.1),
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(

--- a/lib/views/explore/explore_view.dart
+++ b/lib/views/explore/explore_view.dart
@@ -195,9 +195,8 @@ class _ExploreViewState extends State<ExploreView> {
                           child: AnimatedContainer(
                             duration: const Duration(milliseconds: 200),
                             decoration: BoxDecoration(
-                              gradient: isSelected
-                                  ? AppTheme.primaryGradient
-                                  : null,
+                              gradient:
+                                  isSelected ? AppTheme.primaryGradient : null,
                               color: isSelected
                                   ? null
                                   : Colors.white.withValues(alpha: 0.08),
@@ -216,8 +215,10 @@ class _ExploreViewState extends State<ExploreView> {
                                 selected: isSelected,
                                 child: InkWell(
                                   borderRadius: BorderRadius.circular(20),
-                                  focusColor: Colors.white.withValues(alpha: 0.2),
-                                  hoverColor: Colors.white.withValues(alpha: 0.1),
+                                  focusColor:
+                                      Colors.white.withValues(alpha: 0.2),
+                                  hoverColor:
+                                      Colors.white.withValues(alpha: 0.1),
                                   onTap: () {
                                     setState(
                                       () => _selectedCategory = category,

--- a/lib/views/my_learning/my_learning_view.dart
+++ b/lib/views/my_learning/my_learning_view.dart
@@ -73,6 +73,8 @@ class _MyLearningViewState extends State<MyLearningView> {
             selected: isActive,
             child: InkWell(
               borderRadius: BorderRadius.circular(10),
+              focusColor: Colors.white.withValues(alpha: 0.2),
+              hoverColor: Colors.white.withValues(alpha: 0.1),
               onTap: () {
                 setState(() {
                   _selectedTabIndex = index;

--- a/lib/views/profile/profile_view.dart
+++ b/lib/views/profile/profile_view.dart
@@ -260,6 +260,8 @@ class ProfileView extends StatelessWidget {
                                           bottom: Radius.circular(16),
                                         )
                                       : BorderRadius.zero,
+                          focusColor: Colors.white.withValues(alpha: 0.2),
+                          hoverColor: Colors.white.withValues(alpha: 0.1),
                           onTap: items[index].onTap,
                           child: Padding(
                             padding: const EdgeInsets.symmetric(

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -300,6 +300,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(16),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -377,6 +379,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                       color: Colors.transparent,
                       child: InkWell(
                         borderRadius: BorderRadius.circular(16),
+                        focusColor: Colors.white.withValues(alpha: 0.2),
+                        hoverColor: Colors.white.withValues(alpha: 0.1),
                         onTap: () => Navigator.push(
                           context,
                           MaterialPageRoute(
@@ -461,6 +465,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
                     color: Colors.transparent,
                     child: InkWell(
                       borderRadius: BorderRadius.circular(20),
+                      focusColor: Colors.white.withValues(alpha: 0.2),
+                      hoverColor: Colors.white.withValues(alpha: 0.1),
                       onTap: () => Navigator.push(
                         context,
                         MaterialPageRoute(


### PR DESCRIPTION
### 💡 What
Added explicit `focusColor` and `hoverColor` to `InkWell` widgets in:
- `CourseDetailView`
- `VideoPlayerView`
- `MyLearningView`
- `ProfileView`

### 🎯 Why
In Flutter, `InkWell` widgets placed over custom backgrounds (like the glassmorphic cards used in this app) often lose their default hover and focus indicator visibility due to low contrast. This impairs keyboard navigation accessibility and provides poor visual feedback for mouse users.

### 📸 Before/After
**Before:** Clicking or focusing on clickable cards provided little to no visual feedback against the custom background.
**After:** A subtle `Colors.white.withValues(alpha: 0.2)` focus color and `Colors.white.withValues(alpha: 0.1)` hover color provides clear feedback.

### ♿ Accessibility
This change ensures that keyboard focus indicators are visible when navigating interactive elements, significantly improving the app's accessibility for users who rely on keyboard navigation.

---
*PR created automatically by Jules for task [17506574546468508205](https://jules.google.com/task/17506574546468508205) started by @manupawickramasinghe*