### PR TITLE
⚡ Bolt: [performance improvement] Memoize average rating calculation in VideoPlayerView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -71,3 +71,7 @@
 ## 2024-06-20 - Replace .where().toList() and .map().toList() with Collection For Loops
 **Learning:** In Dart, using `.where(condition).toList()` or `.map(fn).toList()` creates an intermediate `WhereIterable` or `MappedIterable` along with their associated closure objects, before immediately iterating over them to create a list. This causes unnecessary intermediate allocations and increases garbage collection overhead, particularly when placed inside a rebuild path or used repeatedly on larger datasets.
 **Action:** Replace these patterns with Dart collection `for` and `if` loops (e.g., `[for (final item in list) if (condition) item]` or `[for (final item in list) fn(item)]`). This constructs the desired list directly without intermediate iterables, reducing garbage collection pressure.
+
+## 2024-06-29 - Flutter StreamBuilder Memoization
+**Learning:** In Flutter, using .fold() inside a StreamBuilder's builder method executes an O(N) operation and allocates a closure on every widget rebuild, even when the stream snapshot hasn't changed.
+**Action:** Use identical() to check if the stream data instance has changed, and only perform O(N) calculations (using a standard for-loop to avoid closures) when a new instance is received, caching the result otherwise.

--- a/lib/views/video/video_player_view.dart
+++ b/lib/views/video/video_player_view.dart
@@ -356,8 +356,17 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
               );
             }
 
-            final avg =
-                reviews.fold(0.0, (s, r) => s + r.rating) / reviews.length;
+            // ⚡ Bolt: Memoize the average calculation based on list identity
+            // to avoid O(N) iteration and closure allocation on every widget rebuild when the list hasn't changed.
+            if (!identical(reviews, _cachedReviews)) {
+              var sum = 0.0;
+              for (final r in reviews) {
+                sum += r.rating;
+              }
+              _cachedAvg = reviews.isEmpty ? 0.0 : sum / reviews.length;
+              _cachedReviews = reviews;
+            }
+            final avg = _cachedAvg;
 
             return GestureDetector(
               behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
### 💡 What
Replaced the `.fold()` based average rating calculation inside `VideoPlayerView`'s `StreamBuilder` with a memoized standard `for` loop.

### 🎯 Why
Inside a `StreamBuilder`'s builder method, calculations execute on every widget rebuild. Calculating the average with `.fold()` triggers an O(N) traversal and creates a new closure every frame, even when the underlying `reviews` list identity hasn't changed. Caching the result based on list identity avoids this overhead.

### 📊 Impact
Reduces CPU overhead and avoids generating intermediate closure objects, reducing garbage collection pressure during `VideoPlayerView` widget rebuilds (e.g., when play state or animations run).

### 🔬 Measurement
Run `flutter test` and confirm all tests pass successfully to ensure functionality remains correct. Using Flutter DevTools' CPU profiler during playback interactions can verify the reduction in closures and `build` duration.

---
*PR created automatically by Jules for task [11837098927118361702](https://jules.google.com/task/11837098927118361702) started by @manupawickramasinghe*